### PR TITLE
Use OrderedMaps instead of Maps in Student

### DIFF
--- a/app/models/student.js
+++ b/app/models/student.js
@@ -22,10 +22,10 @@ let StudentRecord = Immutable.Record({
 	matriculation: 1894,
 	graduation: 1898,
 
-	studies: Immutable.Map(),
-	schedules: Immutable.Map(),
-	overrides: Immutable.Map(),
-	fabrications: Immutable.Map(),
+	studies: Immutable.OrderedMap(),
+	schedules: Immutable.OrderedMap(),
+	overrides: Immutable.OrderedMap(),
+	fabrications: Immutable.OrderedMap(),
 
 	settings: Immutable.Map(),
 })


### PR DESCRIPTION
OrderedMaps maintain their insertion order, thus when we translate from
the raw JSON into a Student and back, we maintain the sort order
instead of losing it.

That's my reason.