### PR TITLE
Remove 'index' support from Study

### DIFF
--- a/app/models/study.js
+++ b/app/models/study.js
@@ -7,14 +7,13 @@ let StudyRecord = Immutable.Record({
 	type: '',
 	abbr: '',
 	title: '',
-	index: 0,
 	revisionYear: null,
 	check: () => undefined,
 })
 
 class Study extends StudyRecord {
 	constructor(args) {
-		let {id, index, revisionYear} = args
+		let {id, revisionYear} = args
 
 		let {type, departmentAbbr, title, check} = getArea(id, revisionYear)
 		// console.log('made a Study', id, title)
@@ -23,19 +22,14 @@ class Study extends StudyRecord {
 			id,
 			type,
 			title,
-			index,
 			check,
 			revisionYear,
 			abbr: departmentAbbr,
 		})
 	}
 
-	reorder(newIndex) {
-		return this.set('index', newIndex)
-	}
-
 	toJSON() {
-		let toKeep = ['id', 'index', 'revisionYear']
+		let toKeep = ['id', 'revisionYear']
 		let filtered = this.toMap()
 			.filter((val, key) => contains(toKeep, key))
 		return filtered.toJS()

--- a/test/models/study.test.js
+++ b/test/models/study.test.js
@@ -4,57 +4,48 @@ import Study from '../../app/models/study.js'
 
 describe('Study', () => {
 	it('is a Study', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		expect(csci instanceof Study).toBe(true)
 	})
 
 	it('can be turned into a JS object', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		expect(csci.toJS() instanceof Object).toBe(true)
 	})
 
 	it('ignores sets on known properties', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		try {
-			csci.index = 3
+			csci.id = 'm-asian'
 		} catch (err) {}
-		expect(csci.index).toBe(0)
+		expect(csci.id).toBe('m-csci')
 	})
 
 	it('holds an area of study for a student', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		let result = csci.toJS()
 
-		let {id, type, abbr, title, index, revisionYear, check} = result
+		let {id, type, abbr, title, revisionYear, check} = result
 
 		expect(id).toBe('m-csci')
 		expect(type).toBe('major')
 		expect(abbr).toBe('CSCI')
 		expect(title).toBe('Computer Science')
-		expect(index).toBe(0)
 		expect(revisionYear).toBe(2014)
 		expect(typeof check).toBe('function')
 	})
 
-	it('supports Study.reorder to rearrange itself', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
-		csci = csci.reorder(3)
-		let result = csci.toJS()
-
-		expect(result.index).toBe(3)
-	})
-
 	it('can turn into JSON', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		let result = JSON.stringify(csci)
 
 		expect(result).toBeTruthy()
 	})
 
 	it('only translates some properties into the JSON bit', () => {
-		let csci = new Study({id: 'm-csci', index: 0, revisionYear: 2014})
+		let csci = new Study({id: 'm-csci', revisionYear: 2014})
 		let result = JSON.stringify(csci)
 
-		expect(result).toBe('{"id":"m-csci","index":0,"revisionYear":2014}')
+		expect(result).toBe('{"id":"m-csci","revisionYear":2014}')
 	})
 })


### PR DESCRIPTION
Originally, this was going to facilitate the rearrangement of areas-of-study in the sidebar. 

We don't currently support rearrangement of areas-of-study in the sidebar. I don't think that we want to. 
We also currently ignore the `index` property when rendering areas into the sidebar.

I'm just going for a complete gutting of this feature-that-never-was.