### PR TITLE
Fix treo after update to 0.4.1

### DIFF
--- a/app/helpers/queryTreoDatabase.js
+++ b/app/helpers/queryTreoDatabase.js
@@ -3,6 +3,7 @@
 //   .use(queryTreoDatabase)
 
 import Promise from 'bluebird'
+import idbRange from 'idb-range'
 import {any, isString, first, last, filter} from 'lodash'
 import deepEql from 'deep-eql'
 import checkAgainstQuery from 'sto-helpers/lib/checkCourseAgainstQuery'
@@ -69,7 +70,7 @@ function query(db, treo) {
 
 					let firstKey = first(keys)
 					let lastKey = last(keys)
-					range = treo.range({
+					range = idbRange({
 						gte: firstKey,
 						// If it's a string, append `uffff` because that's the highest
 						// value in Unicode, which lets us make sure and iterate over all

--- a/app/helpers/queryTreoDatabase.js
+++ b/app/helpers/queryTreoDatabase.js
@@ -7,8 +7,7 @@ import {any, isString, first, last, filter} from 'lodash'
 import deepEql from 'deep-eql'
 import checkAgainstQuery from 'sto-helpers/lib/checkCourseAgainstQuery'
 
-function query(db) {
-	let treo = db.constructor
+function query(db, treo) {
 	let {Store} = treo
 
 	/**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "deep-eql": "0.1.3",
     "dom-storage": "^2.0.1",
     "humanize-plus": "1.5.0",
+    "idb-range": "^2.0.0",
     "immutable": "3.6.2",
     "keymage": "1.1.0",
     "lodash": "2.4.1",


### PR DESCRIPTION
Treo used to (I swear!) expect you to get the `treo` object from the constructor of the `db` param. Now, it passes it in as the second parameter.

Moreover, `treo.range` has been extracted to the `idb-range` package on npm. This updates `queryTreoDatabase` to use that package.