### PR TITLE
Make area of study loading, in the sidebar, async

### DIFF
--- a/app/elements/areaOfStudy.js
+++ b/app/elements/areaOfStudy.js
@@ -1,25 +1,39 @@
-import _ from 'lodash'
 import React from 'react/addons'
+import {map} from 'lodash'
 import RequirementSet from './requirementSet'
 
 let cx = React.addons.classSet
 
-let AreaOfStudy = React.createClass({
-	mixins: [State, Navigation],
+let makeRequirementSets = (props) => {
+	if (!props.areaResult)
+		return []
 
+	let reqSets = map(props.areaResult.details, (reqset) =>
+		React.createElement(RequirementSet,
+			Object.assign({key: reqset.title}, reqset)))
+
+	return reqSets
+}
+
+let AreaOfStudy = React.createClass({
 	propTypes: {
 		area: React.PropTypes.shape({
 			id: React.PropTypes.string.isRequired,
 			title: React.PropTypes.string.isRequired,
+			type: React.PropTypes.string,
+		}).isRequired,
+		areaResult: React.PropTypes.shape({
+			id: React.PropTypes.string.isRequired,
+			title: React.PropTypes.string.isRequired,
 			result: React.PropTypes.bool.isRequired,
+			type: React.PropTypes.string,
 			progress: React.PropTypes.shape({
 				at: React.PropTypes.number.isRequired,
 				of: React.PropTypes.number.isRequired,
 				word: React.PropTypes.string,
 			}).isRequired,
-			type: React.PropTypes.string,
 			details: React.PropTypes.arrayOf(React.PropTypes.object),
-		})
+		}),
 	},
 
 	toggle() {
@@ -27,51 +41,46 @@ let AreaOfStudy = React.createClass({
 	},
 
 	componentWillReceiveProps(nextProps) {
-		this.setState({
-			reqSets: this.makeReqSets(),
-		})
+		this.setState({reqSets: makeRequirementSets(nextProps)})
 	},
 
 	componentWillMount() {
-		this.setState({
-			reqSets: this.makeReqSets(),
-		})
+		this.setState({reqSets: makeRequirementSets(this.props)})
 	},
 
 	getInitialState() {
 		return {
 			expanded: false,
-			reqSets: this.makeReqSets(),
+			reqSets: makeRequirementSets(this.props),
 		}
-	},
-
-	makeReqSets() {
-		let reqSets = _.map(this.props.area.details, (reqset) =>
-				React.createElement(RequirementSet, Object.assign({key: reqset.title}, reqset)))
-		return reqSets
 	},
 
 	render() {
 		// console.log(`render areaOfStudy for ${this.props.area.id}`)
 
+		let progressProps = this.props.areaResult ? {
+				className: this.props.areaResult.progress.word,
+				value: this.props.areaResult.progress.at,
+				max: this.props.areaResult.progress.of,
+		} : {}
+
+		let reqSets = this.state.expanded ? this.state.reqSets : null
+
 		let header = React.createElement('header',
 			{className: 'summary', onClick: this.toggle},
 			React.createElement('h1', null, this.props.area.title),
-			React.createElement('progress', {
-				value: this.props.area.progress.at,
-				max: this.props.area.progress.of,
-				className: this.props.area.progress.word,
-			}))
+			React.createElement('progress', progressProps))
 
 		let classes = cx({
 			'area-of-study': true,
 			open: this.state.expanded,
+			loading: !this.props.areaResult,
 		})
 
 		return React.createElement('div',
-			{key: this.props.area.id, className: classes},
+			{className: classes},
 			header,
-			this.state.expanded ? this.state.reqSets : null)
+			reqSets)
 	},
 })
 

--- a/app/elements/areaOfStudy.js
+++ b/app/elements/areaOfStudy.js
@@ -1,9 +1,5 @@
 import _ from 'lodash'
-import Immutable from 'immutable'
 import React from 'react/addons'
-import {State, Navigation} from 'react-router'
-
-import studentActions from '../flux/studentActions'
 import RequirementSet from './requirementSet'
 
 let cx = React.addons.classSet

--- a/app/elements/areaOfStudy.js
+++ b/app/elements/areaOfStudy.js
@@ -37,7 +37,8 @@ let AreaOfStudy = React.createClass({
 	},
 
 	toggle() {
-		this.setState({expanded: !this.state.expanded})
+		if (this.props.areaResult)
+			this.setState({expanded: !this.state.expanded})
 	},
 
 	componentWillReceiveProps(nextProps) {

--- a/app/elements/graduationStatus.js
+++ b/app/elements/graduationStatus.js
@@ -52,19 +52,21 @@ let GraduationStatus = React.createClass({
 			graduatability: this.state.graduatability,
 		})
 
-		let sections = this.state.areaDetails
-			.groupBy(area => area.type || 'Unknown')
+		let sections = student.areasByType
 			.map((areas, areaType) => {
 				let pluralType = pluralize(2, areaType, areaType === 'emphasis' ? 'emphases' : undefined)
 
 				let areaTypeHeading = React.createElement('header', {className: 'area-type-heading'},
 					React.createElement('h1', null, capitalize(pluralType)))
 
-				let areaElements = areas.map((area, index) => {
+				let areaElements = areas.toList().map((area, index) => {
+					let areaResult = this.state.areaDetails.find(a => a.id === area.id)
+
 					return React.createElement(AreaOfStudy, {
 						key: `${area.id}-${index}`,
-						student: this.props.student,
-						area: area,
+						student,
+						areaResult,
+						area,
 					})
 				}).toJS()
 

--- a/app/elements/graduationStatus.js
+++ b/app/elements/graduationStatus.js
@@ -42,10 +42,15 @@ let GraduationStatus = React.createClass({
 
 	render() {
 		// console.info('graduation-status render', this.props.student)
-		if (!this.props.student)
+		let student = this.props.student
+
+		if (!student)
 			return null
 
-		let summary = React.createElement(StudentSummary, {student: this.props.student, graduatability: this.state.graduatability})
+		let summary = React.createElement(StudentSummary, {
+			student: student,
+			graduatability: this.state.graduatability,
+		})
 
 		let sections = this.state.areaDetails
 			.groupBy(area => area.type || 'Unknown')

--- a/app/elements/graduationStatus.js
+++ b/app/elements/graduationStatus.js
@@ -16,8 +16,10 @@ let GraduationStatus = React.createClass({
 
 	componentWillReceiveProps(nextProps) {
 		let graduatabilityPromise = checkStudentGraduatability(nextProps.student)
+
 		graduatabilityPromise.then((graduationStatus) => {
-			this.setState({graduatability: graduationStatus.graduatability, areaDetails: graduationStatus.areaDetails})
+			let {graduatability, areaDetails} = graduationStatus
+			this.setState({graduatability, areaDetails})
 		})
 	},
 

--- a/app/helpers/checkStudentGraduatability.js
+++ b/app/helpers/checkStudentGraduatability.js
@@ -13,7 +13,8 @@ import checkStudentAgainstArea from './checkStudentAgainstArea'
  * @fulfill {Object} - The details of the students graduation prospects.
  */
 function checkStudentGraduatability(student) {
-	let areaResults = student.studies.map((area) => checkStudentAgainstArea(student, area)).toArray()
+	let areaResults = student.studies.map((area) =>
+		checkStudentAgainstArea(student, area)).toArray()
 	// console.log('areaResults', student.studies.toArray(), areaResults)
 
 	return Promise.all(areaResults).then((areas) => {

--- a/app/helpers/checkStudentGraduatability.js
+++ b/app/helpers/checkStudentGraduatability.js
@@ -11,6 +11,8 @@ import checkStudentAgainstArea from './checkStudentAgainstArea'
  * @param {Student} student
  * @promise GraduatabilityPromise
  * @fulfill {Object} - The details of the students graduation prospects.
+ *    {Boolean} graduatability
+ *    {Immutable.List} areaDetails
  */
 function checkStudentGraduatability(student) {
 	let areaResults = student.studies.map((area) =>

--- a/app/helpers/checkStudentGraduatability.js
+++ b/app/helpers/checkStudentGraduatability.js
@@ -17,8 +17,17 @@ function checkStudentGraduatability(student) {
 	// console.log('areaResults', student.studies.toArray(), areaResults)
 
 	return Promise.all(areaResults).then((areas) => {
-		let graduatability = (_(areas).pluck('result').filter(isTrue).size() - _.size(areas)) >= 1
-		return {graduatability: graduatability, areaDetails: Immutable.List(areas)}
+		let goodAreaCount = _(areas)
+			.pluck('result')
+			.filter(isTrue)
+			.size()
+
+		let graduatability = (goodAreaCount - _.size(areas)) === 0
+
+		return {
+			graduatability: graduatability,
+			areaDetails: Immutable.List(areas),
+		}
 	})
 }
 

--- a/app/models/student.js
+++ b/app/models/student.js
@@ -155,7 +155,7 @@ class Student extends StudentRecord {
 	// area-of-study methods
 
 	get areasByType() {
-		return this.studies.groupBy((study) => study.type)
+		return this.studies.groupBy(study => study.type || 'Unknown')
 	}
 
 	addArea(areaOfStudy) {

--- a/app/styles/app/areaOfStudy.styl
+++ b/app/styles/app/areaOfStudy.styl
@@ -8,6 +8,8 @@
 	overflow: hidden
 	margin-bottom: 0.75em
 
+	$progress-height = 4px
+
 	h1 {
 		padding: $block-edge-padding * 1.5
 		padding-left: $block-edge-padding * 1.5
@@ -22,6 +24,8 @@
 	}
 
 	& > .summary {
+		padding-top: $progress-height / 2
+
 		position: relative
 		cursor: pointer
 
@@ -39,7 +43,7 @@
 		left: 0
 
 		width: 100%
-		height: 4px
+		height: $progress-height
 
 		border: 0
 

--- a/app/styles/app/areaOfStudy.styl
+++ b/app/styles/app/areaOfStudy.styl
@@ -81,7 +81,7 @@
 			progress-track('red')
 		}
 		&.zero {
-			progress-track('blue-gray', $has-track: false)
+			progress-track('blue-gray')
 		}
 	}
 

--- a/app/styles/app/areaOfStudy.styl
+++ b/app/styles/app/areaOfStudy.styl
@@ -36,7 +36,7 @@
 	}
 
 	progress {
-		progress-track('blue-gray')
+		progress-track('blue')
 
 		position: absolute
 		top: 0

--- a/app/styles/app/areaOfStudy.styl
+++ b/app/styles/app/areaOfStudy.styl
@@ -81,7 +81,7 @@
 			progress-track('red')
 		}
 		&.zero {
-			progress-track('red', $has-track: false)
+			progress-track('blue-gray', $has-track: false)
 		}
 	}
 

--- a/app/styles/app/areaOfStudy.styl
+++ b/app/styles/app/areaOfStudy.styl
@@ -100,6 +100,13 @@
 
 		transform: rotate(90deg) scale(0.8)
 	}
+
+	&.loading > .summary::after {
+		ionicon($ionicon-load-c)
+
+		animation: spin 1s infinite ease-in-out
+		font-size: 1em
+	}
 }
 
 .add-area-of-study {

--- a/app/styles/app/requirementSet.styl
+++ b/app/styles/app/requirementSet.styl
@@ -71,11 +71,13 @@ $border-color = rgb(203, 203, 203)
 	}
 
 	&.incomplete::before {
-		ionicon($ionicon-android-checkbox-blank)
+		// ionicon($ionicon-android-checkbox-blank)
+		ionicon($ionicon-close)
 		color: get-color('red')
 	}
 	&.completed::before {
-		ionicon($ionicon-android-checkmark-circle)
+		// ionicon($ionicon-android-checkmark-circle)
+		ionicon($ionicon-checkmark)
 		color: get-color('green')
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 
     "lint": "jscs app/ test/",
     "test": "jest",
-    "travis": "npm run lint & npm run build & npm run test & wait",
+    "travis": "npm run lint && npm run build && npm run test",
     "start": "npm run serve",
     "publish": "npm run clean && npm run build && npm run uglify"
   },


### PR DESCRIPTION
GraduationStatus's rendering shouldn't be blocked by checkStudentAgainstArea, IMO.

Therefore, I've rebuilt chunks of AreaOfStudy and GraduationStatus in order to load the results asychronously.

GradStatus still runs the result finder, but now also renders areas before recieving the results. (This is made possible by loading the area in the Study constructor.)

This might not be enough, still; if we transitions Study to retrieve props in an async fashion, this expects to have everything but the results immediately. Well, let's cross that :bridge: when we come to it.

:shipit:, @drewvolz?