### PR TITLE
Use classnames instead of React.addons.classSet

### DIFF
--- a/app/elements/areaOfStudy.js
+++ b/app/elements/areaOfStudy.js
@@ -1,8 +1,7 @@
-import React from 'react/addons'
+import React from 'react'
 import map from 'lodash/collection/map'
 import RequirementSet from './requirementSet'
-
-let cx = React.addons.classSet
+import cx from 'classnames'
 
 let makeRequirementSets = (props) => {
 	if (!props.areaResult)

--- a/app/elements/booleanArrayRequirement.js
+++ b/app/elements/booleanArrayRequirement.js
@@ -1,6 +1,6 @@
 import map from 'lodash/collection/map'
-import React from 'react/addons'
-let cx = React.addons.classSet
+import React from 'react'
+import cx from 'classnames'
 let {PropTypes} = React
 
 let BooleanArrayRequirement = React.createClass({

--- a/app/elements/booleanRequirement.js
+++ b/app/elements/booleanRequirement.js
@@ -1,5 +1,5 @@
-import React from 'react/addons'
-let cx = React.addons.classSet
+import React from 'react'
+import cx from 'classnames'
 
 let BooleanRequirement = React.createClass({
 	propTypes: {

--- a/app/elements/course.js
+++ b/app/elements/course.js
@@ -1,13 +1,12 @@
 import {_ as lodash, isNull} from 'lodash'
-import React from 'react/addons'
+import React from 'react'
+import cx from 'classnames'
 import {DragDropMixin} from 'react-dnd'
 
 import itemTypes from '../models/itemTypes'
 
 import ExpandedCourse from './expandedCourse'
 import CollapsedCourse from './collapsedCourse'
-
-let cx = React.addons.classSet
 
 let Course = React.createClass({
 	propTypes: {

--- a/app/elements/course.js
+++ b/app/elements/course.js
@@ -73,18 +73,16 @@ let Course = React.createClass({
 			.value()
 
 		return React.createElement('article',
-			Object.assign(
-				{
-					className: cx({
-						course: true,
-						expanded: this.state.isOpen,
-						'has-warnings': hasWarnings,
-						'is-dragging': isDragging,
-					}),
-					onClick: this.toggle,
-				},
-				this.dragSourceFor(itemTypes.COURSE)),
-
+			{
+				className: cx({
+					course: true,
+					expanded: this.state.isOpen,
+					'has-warnings': hasWarnings,
+					'is-dragging': isDragging,
+				}),
+				onClick: this.toggle,
+				...this.dragSourceFor(itemTypes.COURSE),
+			},
 			React.createElement('ul', {className: 'warnings'}, warningEls),
 			courseInfo)
 	},

--- a/app/elements/course.js
+++ b/app/elements/course.js
@@ -1,4 +1,5 @@
-import {_ as lodash, isNull} from 'lodash'
+import {_ as lodash} from 'lodash'
+import isNull from 'lodash/lang/isNull'
 import React from 'react'
 import cx from 'classnames'
 import {DragDropMixin} from 'react-dnd'

--- a/app/elements/courseTable.js
+++ b/app/elements/courseTable.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import React from 'react'
 
 import {expandYear} from 'sto-helpers'

--- a/app/elements/expandedCourse.js
+++ b/app/elements/expandedCourse.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {map} from 'lodash'
+import map from 'lodash/collection/map'
 import {oxford, pluralize} from 'humanize-plus'
 
 import CourseTitle from './courseTitle'

--- a/app/elements/expandedCourse.js
+++ b/app/elements/expandedCourse.js
@@ -96,7 +96,9 @@ let ExpandedCourse = React.createClass({
 
 		// /////
 
-		return React.createElement('div', {className: 'info-rows'}, title, summary, details, toolsEls)
+		return React.createElement('div',
+			{className: 'info-rows'},
+			title, summary, details, toolsEls)
 	},
 })
 

--- a/app/elements/numberObjectRequirement.js
+++ b/app/elements/numberObjectRequirement.js
@@ -1,9 +1,9 @@
 import map from 'lodash/collection/map'
-import React from 'react/addons'
-let cx = React.addons.classSet
-let {PropTypes, createClass} = React
+import React from 'react'
+import cx from 'classnames'
+let {PropTypes} = React
 
-let NumberObjectRequirement = createClass({
+let NumberObjectRequirement = React.createClass({
 	propTypes: {
 		result: PropTypes.bool.isRequired,
 		details: PropTypes.shape({

--- a/app/elements/searchButton.js
+++ b/app/elements/searchButton.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import {Link, State} from 'react-router'
-import {isObject, chain, map} from 'lodash'
+import {chain} from 'lodash'
+import isObject from 'lodash/lang/isObject'
+import map from 'lodash/collection/map'
 
 import {toPrettyTerm} from 'sto-helpers'
 import queryCourseDatabase from '../helpers/queryCourseDatabase'

--- a/app/elements/semester.js
+++ b/app/elements/semester.js
@@ -144,7 +144,7 @@ let Semester = React.createClass({
 		}
 
 		return React.createElement('div',
-			extend(semesterProps, this.dropTargetFor(itemTypes.COURSE)),
+			{...semesterProps, ...this.dropTargetFor(itemTypes.COURSE)},
 			React.createElement('header', {className: 'semester-title'},
 				React.createElement(Link,
 					{

--- a/app/elements/semester.js
+++ b/app/elements/semester.js
@@ -1,4 +1,4 @@
-import {isUndefined, extend} from 'lodash'
+import isUndefined from 'lodash/lang/isUndefined'
 import {DragDropMixin} from 'react-dnd'
 import Promise from 'bluebird'
 import React from 'react'

--- a/app/elements/semester.js
+++ b/app/elements/semester.js
@@ -1,10 +1,11 @@
 import {isUndefined, extend} from 'lodash'
 import {DragDropMixin} from 'react-dnd'
 import Promise from 'bluebird'
-import React from 'react/addons'
+import React from 'react'
 import {Link} from 'react-router'
 import {pluralize} from 'humanize-plus'
 import Immutable from 'immutable'
+import cx from 'classnames'
 
 import {add, countCredits, semesterName, isCurrentSemester} from 'sto-helpers'
 import Course from './course'
@@ -12,8 +13,6 @@ import MissingCourse from './missingCourse'
 import EmptyCourseSlot from './emptyCourseSlot'
 import studentActions from '../flux/studentActions'
 import itemTypes from '../models/itemTypes'
-
-let cx = React.addons.classSet
 
 let Semester = React.createClass({
 	mixins: [DragDropMixin],

--- a/app/elements/semester.js
+++ b/app/elements/semester.js
@@ -46,9 +46,7 @@ let Semester = React.createClass({
 		let activeSchedules = nextProps.student.activeSchedules
 		let schedule = activeSchedules.find((s) => s.year === this.props.year && s.semester === this.props.semester)
 
-		Promise.all([schedule.courses, schedule.validate()]).then((results) => {
-			let [courses, validation] = results
-
+		Promise.all([schedule.courses, schedule.validate()]).then(([courses, validation]) => {
 			this.setState({
 				schedule,
 				courses: Immutable.List(courses),

--- a/app/elements/someArrayRequirement.js
+++ b/app/elements/someArrayRequirement.js
@@ -1,6 +1,6 @@
 import map from 'lodash/collection/map'
-import React from 'react/addons'
-let cx = React.addons.classSet
+import React from 'react'
+import cx from 'classnames'
 let {PropTypes} = React
 
 let SomeArrayRequirement = React.createClass({

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.12",
+    "classnames": "^1.1.4",
     "combinations-generator": "^1.0.1",
     "humanize-plus": "^1.5.0",
     "idb-range": "^2.0.0",


### PR DESCRIPTION
Also converges on using `{...{}}` (ES7 object destructuring), instead of `Object.assign` or `_.extend`.