### PR TITLE
Only render the required chunks for courses in <AreaOfStudy/>

### DIFF
--- a/benchmarks/students-benchmark.js
+++ b/benchmarks/students-benchmark.js
@@ -11,61 +11,58 @@ import range from 'lodash/utility/range'
 import size from 'lodash/collection/size'
 import sparkly from 'sparkly'
 import sum from 'lodash/collection/sum'
-import loadArea from '../bin/load-area'
+import loadArea from '../bin/lib/load-area'
 
 function now(other=[]) {
-    let time = process.hrtime(other)
-    return time[0] * 1e3 + time[1] / 1e6
+	let time = process.hrtime(other)
+	return time[0] * 1e3 + time[1] / 1e6
 }
 
 function loadStudents(dir) {
-    return fs.readdirSync(dir)
-        .filter(name => !includes(name, '.ip'))
-        .filter(junk.not)
-        .map(path => dir + path)
-        .map(path => fs.readFileSync(path, 'utf-8'))
-        .map(JSON.parse)
+	return fs.readdirSync(dir)
+		.filter(name => !includes(name, '.ip'))
+		.filter(junk.not)
+		.map(path => dir + path)
+		.map(path => fs.readFileSync(path, 'utf-8'))
+		.map(JSON.parse)
 }
 
 function benchmark({runs, graph}) {
-    loadStudents('./test/example-students/')
-        .forEach(({courses=[], overrides={}, areas=[]}) => {
-            areas.forEach(areaInfo => {
-                console.log(`the '${areaInfo.name}' ${areaInfo.type} (${areaInfo.revision})`)
-                let areaData = loadArea(areaInfo)
-                let times = range(runs).map(() => {
-                    const start = process.hrtime()
-                    evaluate({courses, overrides}, areaData)
-                    return now(start)
-                })
+	loadStudents('./test/example-students/')
+		.forEach(({courses=[], overrides={}, areas=[]}) => {
+			areas.forEach(areaInfo => {
+				console.log(`the '${areaInfo.name}' ${areaInfo.type} (${areaInfo.revision})`)
+				let areaData = loadArea(areaInfo)
+				let times = range(runs).map(() => {
+					const start = process.hrtime()
+					evaluate({courses, overrides}, areaData)
+					return now(start)
+				})
 
-                const avg = sum(times) / size(times)
-                if (graph) {
-                    console.log(`  ${sparkly(times)}\n`)
-                }
-                console.log(`  average time: ${ms(avg)} (over ${runs} runs)\n`)
-            })
-        })
+				const avg = sum(times) / size(times)
+				if (graph) {
+					console.log(`  ${sparkly(times)}\n`)
+				}
+				console.log(`  average time: ${ms(avg)} (over ${runs} runs)\n`)
+			})
+		})
 }
 
 function cli() {
-    const args = meow({
-        help: `
-            Usage
-              node students-benchmark [-r, --runs <number>] [--(no-)graph]
-        `,
-        pkg: info,
-    })
+	const args = meow({
+		help: `Usage: node students-benchmark [-r, --runs <number>] [--(no-)graph]`,
+		pkg: info,
+	})
 
-    if (args.flags.args) {
-        console.log(args.flags)
-    }
+	if (args.flags.args) {
+		console.log(args.flags)
+	}
 
-    const runs = args.flags.r || args.flags.runs || 50
-    const graph = args.flags.graph
-    benchmark({runs, graph})
+	const runs = args.flags.r || args.flags.runs || 50
+	const graph = args.flags.graph
+	benchmark({runs, graph})
 }
 
 if (require.main === module) {
-    cli()
+	cli()
 }

--- a/src/base/variables.scss
+++ b/src/base/variables.scss
@@ -28,3 +28,9 @@ $base-border-radius: 3px;
 $react-list-select-accent: color('blue', '200');
 $react-list-select-selected: color('blue', '50');
 $react-list-select-disabled: color('gray', '500');
+
+
+// area of study colors
+$computed-success-background: hsl(153, 25%, 95%);
+$computed-success-color: hsl(153, 43%, 42%);
+$computed-failure-color: hsl(3, 100%, 61%);

--- a/src/components/expression--course.js
+++ b/src/components/expression--course.js
@@ -1,7 +1,16 @@
 import React, {Component, PropTypes} from 'react'
 import cx from 'classnames'
+import includes from 'lodash/collection/includes'
 
 import './expression--course.scss'
+
+function hasOwnKey(course, key) {
+	return (
+		course.hasOwnProperty(key) &&
+		course._extraKeys &&
+		includes(course._extraKeys, key)
+	)
+}
 
 export default class CourseExpression extends Component {
 	static propTypes = {
@@ -20,32 +29,26 @@ export default class CourseExpression extends Component {
 	render() {
 		const department = this.props.department.join('/')
 
-		const international = this.props.international
-			? <span className='course--international'>I</span>
-			: null
-		const lab = this.props.lab
-			? <span className='course--lab'>L</span>
-			: null
+		const international = hasOwnKey(this.props, 'international') &&
+			<span className='course--international'>I</span>
+		const lab = hasOwnKey(this.props, 'lab') &&
+			<span className='course--lab'>L</span>
 
-		const section = this.props.section
-			? <span className='course--section'>[{this.props.section}]</span>
-			: null
+		const section = hasOwnKey(this.props, 'section') &&
+			<span className='course--section'>[{this.props.section}]</span>
 
-		const year = this.props.year
-			? <span className='course--year'>{this.props.year}</span>
-			: null
-		const semester = this.props.semester
-			? <span className='course--semester'>S{this.props.semester}</span>
-			: null
+		const year = hasOwnKey(this.props, 'year') &&
+			<span className='course--year'>{this.props.year}</span>
+		const semester = hasOwnKey(this.props, 'semester') &&
+			<span className='course--semester'>S{this.props.semester}</span>
 
 		/////
 
-		const temporalIdentifiers = (semester || year)
-			? (<div className='temporal'>
+		const temporalIdentifiers = (semester || year) &&
+			(<div className='temporal'>
 				{semester}
 				{year}
 			</div>)
-			: null
 
 		return (
 			<span className={cx('course', {matched: this.props._result})} style={this.props.style}>

--- a/src/components/expression--course.js
+++ b/src/components/expression--course.js
@@ -5,10 +5,13 @@ import includes from 'lodash/collection/includes'
 import './expression--course.scss'
 
 function hasOwnKey(course, key) {
+	// In order to have an "own key":
+	// 1. the course MUST have the key on its object
+	// 2. the key MUST NOT appear in the _extraKeys array
+	//      (which may or may not exist)
 	return (
 		course.hasOwnProperty(key) &&
-		course._extraKeys &&
-		includes(course._extraKeys, key)
+		!includes(course._extraKeys || [], key)
 	)
 }
 

--- a/src/components/expression--course.js
+++ b/src/components/expression--course.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react'
 import cx from 'classnames'
 
-import './expression--course'
+import './expression--course.scss'
 
 export default class CourseExpression extends Component {
 	static propTypes = {

--- a/src/components/expression--course.scss
+++ b/src/components/expression--course.scss
@@ -31,7 +31,7 @@
 			font-size: 0.7em;
 		}
 		& > :nth-child(2) {
-			font-weight: bold;
+			font-weight: 500;
 		}
 	}
 
@@ -53,7 +53,8 @@
 				rgba(0, 0, 0, 0.5) 17%,
 				white 20%,
 				white 44%,
-				rgba(0, 0, 0, 0.5) 46%);
+				rgba(0, 0, 0, 0.5) 46%
+			);
 		}
 	}
 }

--- a/src/components/expression--course.scss
+++ b/src/components/expression--course.scss
@@ -5,6 +5,7 @@
 
 	.course {
 		display: flex;
+		cursor: inherit;
 	}
 
 	font-size: 0.9em;

--- a/src/components/expression.scss
+++ b/src/components/expression.scss
@@ -1,5 +1,6 @@
 @import '../mixins/card';
 @import '../mixins/color';
+@import '../base/variables.scss';
 
 .expression {
 	display: inline-block;
@@ -57,16 +58,16 @@
 	}
 
 	&.computed.computed-success {
-		background-color: hsl(153, 25%, 95%);
+		background-color: $computed-success-background;
 	}
 	&.computed.computed-success::after {
 		content: '✓';
-		color: hsl(153, 43%, 42%);
+		color: $computed-success-color;
 	}
 
 	&.computed.computed-failure::after {
 		content: '×';
-		color: hsl(3, 100%, 61%);
+		color: $computed-failure-color;
 		font-weight: bold;
 	}
 }

--- a/src/components/expression.scss
+++ b/src/components/expression.scss
@@ -52,7 +52,7 @@
 
 	&.computed::after {
 		font-family: monospace;
-		margin-left: 0.35em;
+		margin-left: 0.4em;
 		display: inline-block;
 	}
 

--- a/src/components/expression.scss
+++ b/src/components/expression.scss
@@ -22,6 +22,7 @@
 .expression--description:not(:only-child) {
 	display: block;
 	width: 100%;
+	margin-top: 0.35em;
 	margin-bottom: 0.35em;
 }
 

--- a/src/components/requirement.js
+++ b/src/components/requirement.js
@@ -50,7 +50,8 @@ export default class Requirement extends Component {
 			? null
 			: (
 				<h2 className={`requirement--title ${wasComputed ? computationResult ? 'computed-success' : 'computed-failure' : 'computed-not'}`}>
-					{this.props.computed ? '✓' : '×'}{' '}
+					<span className='requirement--title-status'>{this.props.computed ? '✓' : '×'}</span>
+					{' '}
 					{this.props.name}
 					{' '}
 					<Button className='requirement--override-button' onClick={ev => this.props.toggleOverride({ev, path: this.props.path})}>

--- a/src/components/requirement.scss
+++ b/src/components/requirement.scss
@@ -1,7 +1,16 @@
 @import '../mixins/card';
+@import '../base/variables.scss';
 
 .requirement {
-	margin: 0 0.25em 0.25em 0.5em;
+	margin: 0.25em 0.25em 0.25em 0.5em;
+}
+
+.requirement + .requirement {
+	margin-top: 0.75em;
+}
+
+.requirement:last-child {
+	margin-bottom: 0.5em;
 }
 
 .requirement .requirement {
@@ -30,23 +39,32 @@
 
 .requirement--title {
 	font-size: 1em;
-	font-weight: normal;
+	font-weight: 500;
 
 	border-bottom: $material-divider;
 	padding: 0.2em 0.15em;
 }
 
+.requirement--title.computed-success {
+	background-color: $computed-success-background;
+}
+
+.requirement--title-status {
+	margin-right: 0.2em;
+}
+.requirement--title.computed-success .requirement--title-status {
+	color: $computed-success-color;
+}
+
 .requirement .requirement .requirement--title {
 	text-align: center;
-	font-weight: bold;
 
-	font-size: 0.8em;
+	font-size: 0.9em;
 	margin: 0;
 }
 
 .requirement .requirement .requirement .requirement--title {
 	text-align: left;
-	font-weight: normal;
 }
 
 .requirement--title,
@@ -55,8 +73,8 @@
 .requirement--filter,
 .requirement--override-buttons {
 	width: 100%;
-	padding-top: 0.4em;
-	padding-bottom: 0.4em;
+	padding-top: 0.2em;
+	padding-bottom: 0.2em;
 }
 
 .requirement--message {

--- a/src/lib/compute-chunk.js
+++ b/src/lib/compute-chunk.js
@@ -6,6 +6,7 @@ import compact from 'lodash/array/compact'
 import countCourses from './count-courses'
 import countCredits from './count-credits'
 import countDepartments from './count-departments'
+import difference from 'lodash/array/difference'
 import every from 'lodash/collection/every'
 import filterByWhereClause from './filter-by-where-clause'
 import find from 'lodash/collection/find'
@@ -14,6 +15,7 @@ import forEach from 'lodash/collection/forEach'
 import getMatchesFromChildren from './get-matches-from-children'
 import getMatchesFromFilter from './get-matches-from-filter'
 import getOccurrences from './get-occurrences'
+import keys from 'lodash/object/keys'
 import map from 'lodash/collection/map'
 import simplifyCourse from './simplify-course'
 import stringify from 'json-stable-stringify'
@@ -156,6 +158,11 @@ export function computeCourse({expr, courses, dirty}) {
 
 	const match = assign(expr.$course, foundCourse)
 	const crsid = simplifyCourse(match)
+
+	const keysNotFromQuery = difference(keys(expr.$course), keys(foundCourse))
+	if (keysNotFromQuery.length) {
+		match._extraKeys = keysNotFromQuery
+	}
 
 	if (dirty.has(crsid)) {
 		return {computedResult: false, match}

--- a/src/lib/compute-chunk.js
+++ b/src/lib/compute-chunk.js
@@ -6,7 +6,7 @@ import compact from 'lodash/array/compact'
 import countCourses from './count-courses'
 import countCredits from './count-credits'
 import countDepartments from './count-departments'
-import difference from 'lodash/array/difference'
+import xor from 'lodash/array/xor'
 import every from 'lodash/collection/every'
 import filterByWhereClause from './filter-by-where-clause'
 import find from 'lodash/collection/find'
@@ -156,13 +156,13 @@ export function computeCourse({expr, courses, dirty}) {
 		return {computedResult: false}
 	}
 
+	const keysNotFromQuery = xor(keys(expr.$course), keys(foundCourse))
+	if (keysNotFromQuery.length) {
+		expr.$course._extraKeys = keysNotFromQuery
+	}
+
 	const match = assign(expr.$course, foundCourse)
 	const crsid = simplifyCourse(match)
-
-	const keysNotFromQuery = difference(keys(expr.$course), keys(foundCourse))
-	if (keysNotFromQuery.length) {
-		match._extraKeys = keysNotFromQuery
-	}
 
 	if (dirty.has(crsid)) {
 		return {computedResult: false, match}

--- a/test/areas/compute-boolean.test.js
+++ b/test/areas/compute-boolean.test.js
@@ -270,9 +270,9 @@ describe('computeBoolean', () => {
                     _result: true,
                     _counted: 3,
                     _matches: [
-                        {department: ['ART'], number: 120, credits: 1.0},
-                        {department: ['ART'], number: 104, credits: 1.0},
-                        {department: ['ART'], number: 105, credits: 1.0},
+                        {department: ['ART'], number: 120, credits: 1.0, _extraKeys: ['credits']},
+                        {department: ['ART'], number: 104, credits: 1.0, _extraKeys: ['credits']},
+                        {department: ['ART'], number: 105, credits: 1.0, _extraKeys: ['credits']},
                     ],
                 },
                 {
@@ -287,9 +287,9 @@ describe('computeBoolean', () => {
                     _result: true,
                     _counted: 3,
                     _matches: [
-                        {department: ['ART'], number: 120, credits: 1.0},
-                        {department: ['ART'], number: 104, credits: 1.0},
-                        {department: ['ART'], number: 105, credits: 1.0},
+                        {department: ['ART'], number: 120, credits: 1.0, _extraKeys: ['credits']},
+                        {department: ['ART'], number: 104, credits: 1.0, _extraKeys: ['credits']},
+                        {department: ['ART'], number: 105, credits: 1.0, _extraKeys: ['credits']},
                     ],
                 },
             ],
@@ -297,9 +297,9 @@ describe('computeBoolean', () => {
         })
         expect(computedResult).to.be.true
         expect(matches).to.deep.equal([
-            {department: ['ART'], number: 120, credits: 1.0},
-            {department: ['ART'], number: 104, credits: 1.0},
-            {department: ['ART'], number: 105, credits: 1.0},
+            {department: ['ART'], number: 120, credits: 1.0, _extraKeys: ['credits']},
+            {department: ['ART'], number: 104, credits: 1.0, _extraKeys: ['credits']},
+            {department: ['ART'], number: 105, credits: 1.0, _extraKeys: ['credits']},
         ])
     })
 

--- a/test/areas/compute-course.test.js
+++ b/test/areas/compute-course.test.js
@@ -78,7 +78,7 @@ describe('computeCourse', () => {
 
         const query = {
             $type: 'course',
-            $course: {department: ['ART'], number: 250, crsid: 2015},
+            $course: {department: ['ART'], number: 250, crsid: 20951},
         }
 
         const {computedResult, match} = computeCourse({
@@ -88,6 +88,11 @@ describe('computeCourse', () => {
         expect(computedResult)
             .to.be.true
         expect(match)
-            .to.deep.equal({department: ['ART'], number: 250, crsid: 2015})
+            .to.deep.equal({
+                department: ['ART'],
+                number: 250,
+                crsid: 20951,
+                _extraKeys: ['crsid'],
+            })
     })
 })

--- a/test/areas/compute-modifier.test.js
+++ b/test/areas/compute-modifier.test.js
@@ -249,9 +249,9 @@ describe('computeModifier', () => {
             expect(computedResult)
                 .to.be.true
             expect(matches).to.deep.equal([
-                {department: ['REL'], number: 111, credits: 1},
-                {department: ['REL'], number: 112, credits: 1},
-                {department: ['CSCI'], number: 251, credits: 1},
+                {department: ['REL'], number: 111, credits: 1.0, _extraKeys: ['credits']},
+                {department: ['REL'], number: 112, credits: 1.0, _extraKeys: ['credits']},
+                {department: ['CSCI'], number: 251, credits: 1.0, _extraKeys: ['credits']},
             ])
             expect(counted)
                 .to.equal(3)
@@ -310,9 +310,9 @@ describe('computeModifier', () => {
             expect(computedResult)
                 .to.be.true
             expect(matches).to.deep.equal([
-                {department: ['CHEM', 'BIO'], number: 111, credits: 1},
-                {department: ['CHEM', 'BIO'], number: 112, credits: 1},
-                {department: ['CSCI'], number: 251, credits: 1},
+                {department: ['CHEM', 'BIO'], number: 111, credits: 1.0, _extraKeys: ['credits']},
+                {department: ['CHEM', 'BIO'], number: 112, credits: 1.0, _extraKeys: ['credits']},
+                {department: ['CSCI'], number: 251, credits: 1.0, _extraKeys: ['credits']},
             ])
             expect(counted)
                 .to.equal(3)
@@ -372,8 +372,8 @@ describe('computeModifier', () => {
             expect(computedResult)
                 .to.be.true
             expect(matches).to.deep.equal([
-                {department: ['REL'], number: 111, credits: 1},
-                {department: ['CSCI'], number: 251, credits: 1},
+                {department: ['REL'], number: 111, credits: 1.0, _extraKeys: ['credits']},
+                {department: ['CSCI'], number: 251, credits: 1.0, _extraKeys: ['credits']},
             ])
             expect(counted)
                 .to.equal(2)
@@ -462,8 +462,8 @@ describe('computeModifier', () => {
         expect(courseResults.computedResult)
             .to.be.true
         expect(courseResults.matches).to.deep.equal([
-            {department: ['CHEM', 'BIO'], number: 111, credits: 1.0},
-            {department: ['CHEM', 'BIO'], number: 112, credits: 1.0},
+            {department: ['CHEM', 'BIO'], number: 111, credits: 1.0, _extraKeys: ['credits']},
+            {department: ['CHEM', 'BIO'], number: 112, credits: 1.0, _extraKeys: ['credits']},
         ])
         expect(courseResults.counted)
             .to.equal(2)
@@ -471,8 +471,8 @@ describe('computeModifier', () => {
         expect(departmentResults.computedResult)
             .to.be.true
         expect(departmentResults.matches).to.deep.equal([
-            {department: ['CHEM', 'BIO'], number: 111, credits: 1.0},
-            {department: ['CHEM', 'BIO'], number: 112, credits: 1.0},
+            {department: ['CHEM', 'BIO'], number: 111, credits: 1.0, _extraKeys: ['credits']},
+            {department: ['CHEM', 'BIO'], number: 112, credits: 1.0, _extraKeys: ['credits']},
         ])
         expect(departmentResults.counted)
             .to.equal(2)

--- a/test/example-students/computer-science-load-1.json
+++ b/test/example-students/computer-science-load-1.json
@@ -7,7 +7,7 @@
         {"department": ["CSCI"], "number": 252, "crsid": 4},
         {"department": ["CSCI"], "number": 253, "crsid": 5},
         {"department": ["CSCI"], "number": 263, "crsid": 6},
-        {"department": ["CSCI"], "number": 273, "crsid": 7},
+        {"department": ["CSCI"], "number": 273, "crsid": 7, "year": 2015},
         {"department": ["CSCI"], "number": 276, "crsid": 8},
         {"department": ["CSCI"], "number": 284, "crsid": 9},
         {"department": ["CSCI"], "number": 300, "crsid": 10, "year": 2014, "semester": 1},


### PR DESCRIPTION
Before, it would render all of the information from the matched course; now, it only renders the information in the requirement.

---

We have to merge the course query and found course objects when we encounter them, but that led to rendering all of the information from the merged course in the block.

Which felt to me like it implied that you had to have taken this specific course, when all it meant was that this course happened to match.