### PR TITLE
Show subtitles on courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 - Stuff (this should be the last changelog with this entry…)
 - Began automating changelog/releases/stuff
+- Display "subtitles" for some courses
+	- Show subtitles on seminars and topics courses
 
 
 ## [3.0.0-beta.1] - 2015-10-09

--- a/src/components/course-title.js
+++ b/src/components/course-title.js
@@ -12,7 +12,7 @@ export default class CourseTitle extends Component {
 		const {name, title, type} = this.props
 		const isIndependent = /^I[RS]/.test(name)
 		let courseName = title || name
-		let showSubtitle = false
+		let subtitle = undefined
 
 		if (isIndependent) {
 			courseName = name
@@ -22,18 +22,18 @@ export default class CourseTitle extends Component {
 		}
 		else if (type === 'Topic') {
 			courseName = `${name.replace(/top.*: */gi, '')}`
-			showSubtitle = true
+			subtitle = title
 		}
 		else if (type === 'Seminar') {
-			courseName = `${name.replace(/sem.*: */gi, '')}`
-			showSubtitle = true
+			courseName = title
+			subtitle = name
 		}
 
 		return (
 			<header>
 				<h1 className='title'>{courseName}</h1>
-				{showSubtitle
-					? <h2 className='subtitle'>{title}</h2>
+				{subtitle && subtitle.length
+					? <h2 className='subtitle'>{subtitle}</h2>
 					: null}
 			</header>
 		)

--- a/src/components/course-title.js
+++ b/src/components/course-title.js
@@ -12,6 +12,7 @@ export default class CourseTitle extends Component {
 		const {name, title, type} = this.props
 		const isIndependent = /^I[RS]/.test(name)
 		let courseName = title || name
+		let showSubtitle = false
 
 		if (isIndependent) {
 			courseName = name
@@ -20,10 +21,21 @@ export default class CourseTitle extends Component {
 			}
 		}
 		else if (type === 'Topic') {
-			courseName = name
-			courseName = courseName.replace(/top.*: */gi, '')
+			courseName = `${name.replace(/top.*: */gi, '')}`
+			showSubtitle = true
+		}
+		else if (type === 'Seminar') {
+			courseName = `${name.replace(/sem.*: */gi, '')}`
+			showSubtitle = true
 		}
 
-		return <h1 className='title'>{courseName}</h1>
+		return (
+			<header>
+				<h1 className='title'>{courseName}</h1>
+				{showSubtitle
+					? <h2 className='subtitle'>{title}</h2>
+					: null}
+			</header>
+		)
 	}
 }

--- a/src/components/course.scss
+++ b/src/components/course.scss
@@ -19,6 +19,7 @@
 	}
 
 	.title,
+	.subtitle,
 	.summary {
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -26,7 +27,8 @@
 		cursor: grab;
 	}
 
-	.title {
+	.title,
+	.subtitle, {
 		margin-top: 0;
 		margin-bottom: 0;
 		line-height: 1.2;
@@ -34,6 +36,10 @@
 		font-size: 1em;
 		font-weight: 500;
 		font-family: $heading-font-stack;
+	}
+
+	.subtitle {
+		font-size: 0.75em;
 	}
 
 	.title,
@@ -148,7 +154,8 @@
 .course.expanded {
 	color: $text-color;
 
-	.title {
+	.title,
+	.subtitle {
 		overflow: visible;
 		white-space: normal;
 	}


### PR DESCRIPTION
When showing courses whose `name` and `title` are often different, such as for Seminar and Topics courses, we should show both the name and the title.