### PR TITLE
use shiny Webpack features

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@ globals:
   require: false
   process: false
   VERSION: false
+  debug: false
 
 plugins:
   - eslint-plugin-react

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,9 +16,9 @@ globals:
   global: false
   require: false
   process: false
-  VERSION: false
-  DEV: false
-  debug: false
+  VERSION: false  # inserted by webpack.DefinePlugin
+  DEV: false  # inserted by webpack.DefinePlugin
+  debug: false  # inserted by webpack.DefinePlugin
 
 plugins:
   - eslint-plugin-react

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@ globals:
   global: false
   require: false
   process: false
+  VERSION: false
 
 plugins:
   - eslint-plugin-react

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@ globals:
   require: false
   process: false
   VERSION: false
+  DEV: false
   debug: false
 
 plugins:

--- a/.webpackrc
+++ b/.webpackrc
@@ -1,6 +1,7 @@
 /* eslint no-var:0 */
 /* global module */
 
+// shim Promise because node 0.10 doesn't support native promises
 global.Promise = require('bluebird')
 var pkg = require('./package.json')
 var webpack = require('webpack')

--- a/.webpackrc
+++ b/.webpackrc
@@ -1,7 +1,6 @@
 /* eslint no-var:0 */
 /* global module */
 
-global.Promise = require('bluebird')
 var pkg = require('./package.json')
 var webpack = require('webpack')
 

--- a/.webpackrc
+++ b/.webpackrc
@@ -87,6 +87,7 @@ var config = {
 
 		new webpack.ProvidePlugin({
 			Promise: 'bluebird',
+			debug: 'debug',
 		}),
 
 		new webpack.DefinePlugin({

--- a/.webpackrc
+++ b/.webpackrc
@@ -90,6 +90,10 @@ var config = {
 		new webpack.ProvidePlugin({
 			Promise: 'bluebird',
 		}),
+
+		new webpack.DefinePlugin({
+			VERSION: JSON.stringify(pkg.version),
+		}),
 	],
 
 	module: {

--- a/.webpackrc
+++ b/.webpackrc
@@ -97,6 +97,7 @@ var config = {
 
 		new webpack.DefinePlugin({
 			VERSION: JSON.stringify(pkg.version),
+			DEV: isDev,
 		}),
 	],
 

--- a/.webpackrc
+++ b/.webpackrc
@@ -9,10 +9,9 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlPlugin = require('./scripts/webpack/html-plugin')
 var buildFilename = require('./scripts/webpack/build-filename')
 
-// figure out if we're running `webpack` or `webpack-dev-server`
-// we'll use this as the default for `isDev`
-var isDev = (process.argv[1] || '').indexOf('webpack-dev-server') !== -1
-var isTest = (process.argv[1] || '').indexOf('karma') !== -1
+var isProduction = (process.env.NODE_ENV === 'production')
+var isDev = (process.env.NODE_ENV === 'dev')
+var isTest = (process.env.NODE_ENV === 'test')
 
 var entryPoint = './src/start.js'
 var outputFolder = 'build/'
@@ -180,7 +179,7 @@ else if (isTest) {
 }
 
 // production
-else {
+else if (isProduction) {
 	config.devtool = 'source-map'
 
 	config.stats.children = false
@@ -214,6 +213,10 @@ else {
 		test: /\.scss$/,
 		loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader'),
 	})
+}
+
+else {
+	throw new Error('Unknown environment! Not dev, production, nor test!')
 }
 
 module.exports = config

--- a/.webpackrc
+++ b/.webpackrc
@@ -93,7 +93,11 @@ var config = {
 		// Ignore the "full" schema in js-yaml's module, because it brings in esprima
 		// to support the !!js/function type. We don't use and have no need for it, so
 		// tell webpack to ignore it.
-		new webpack.IgnorePlugin(/schema\/default_full/, /js-yaml/),
+		// new webpack.IgnorePlugin(/schema\/default_full/, /js-yaml/),
+		new webpack.NormalModuleReplacementPlugin(/schema\/default_full$/, function(result) {
+			// console.error('NormalModuleReplacementPlugin', arguments)
+			result.request = result.request.replace('default_full', 'default_safe')
+		}),
 
 		new webpack.DefinePlugin({
 			VERSION: JSON.stringify(pkg.version),

--- a/.webpackrc
+++ b/.webpackrc
@@ -1,6 +1,7 @@
 /* eslint no-var:0 */
 /* global module */
 
+global.Promise = require('bluebird')
 var pkg = require('./package.json')
 var webpack = require('webpack')
 

--- a/.webpackrc
+++ b/.webpackrc
@@ -90,6 +90,11 @@ var config = {
 			debug: 'debug',
 		}),
 
+		// Ignore the "full" schema in js-yaml's module, because it brings in esprima
+		// to support the !!js/function type. We don't use and have no need for it, so
+		// tell webpack to ignore it.
+		new webpack.IgnorePlugin(/schema\/default_full/, /js-yaml/),
+
 		new webpack.DefinePlugin({
 			VERSION: JSON.stringify(pkg.version),
 		}),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "benchmark": "babel-node -- ./benchmarks/students-benchmark.js",
     "build": "env NODE_ENV=production webpack --config .webpackrc --bail --production --progress",
-    "build:dev": "webpack --config .webpackrc --bail --progress",
+    "build:dev": "env NODE_ENV=dev webpack --config .webpackrc --bail --progress",
     "build:areas": "./bin/compile-areas area-data/ --out-dir build/areas/",
     "build:ci": "npm run build -- --no-progress",
     "build:peg": "pegjs < src/lib/parse-hanson-string.pegjs | babel --compact 'true' | js-beautify $npm_package_config_beautify > src/lib/parse-hanson-string.js",
@@ -35,8 +35,10 @@
     "precopy": "npm run clean",
     "prestart": "npm run copy",
     "profile": "cat profile/README.md",
-    "start": "webpack-dev-server --config .webpackrc --progress",
-    "stats": "webpack --config .webpackrc --bail --profile --json > stats.json && open http://webpack.github.io/analyse/",
+    "start": "env NODE_ENV=dev webpack-dev-server --config .webpackrc --progress",
+    "stats": "env NODE_ENV=production npm run stats:base",
+    "stats:base": "webpack --config .webpackrc --bail --profile --json > stats.json && open http://webpack.github.io/analyse/",
+    "stats:dev": "env NODE_ENV=dev npm run stats:base",
     "test": "npm run mocha",
     "test:browser": "npm run karma",
     "test:students": "mocha ./bin/test-students"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "classnames": "2.2.0",
     "codemirror": "5.8.0",
     "combinations-generator": "1.0.1",
+    "debug": "2.2.0",
     "fuzzysearch": "1.0.3",
     "history": "1.13.1",
     "humanize-plus": "1.5.0",

--- a/src/models/student.js
+++ b/src/models/student.js
@@ -8,7 +8,6 @@ import {v4 as uuid} from 'node-uuid'
 import stringify from 'json-stable-stringify'
 import present from 'present'
 
-import {version as currentVersionString} from '../../package.json'
 import checkGraduatability from '../lib/check-student-graduatability'
 
 import randomChar from '../helpers/random-char'
@@ -33,7 +32,7 @@ const now = new Date()
 const StudentRecord = Immutable.Record({
 	id: null,
 	name: null,
-	version: currentVersionString,
+	version: VERSION,
 
 	creditsNeeded: 35,
 
@@ -76,7 +75,7 @@ export default class Student extends StudentRecord {
 				student = student.set('name', encodedStudent.name || 'Student ' + randomChar())
 				student = student.set('dateCreated', encodedStudent.dateCreated || new Date())
 				student = student.set('dateLastModified', encodedStudent.dateLastModified || new Date())
-				student = student.set('version', currentVersionString)
+				student = student.set('version', VERSION)
 
 				forEach((encodedStudent.studies || []), study => {
 					student = student.addArea(study)


### PR DESCRIPTION
I started down this path because I noticed (using source-map-explorer[1]) that Esprima was being bundled into the browser bundle.

So I used the `webpack.IgnorePlugin` to ignore it.

Then I got annoyed by the constant logging of messages during tests, so I decided that I should use a logging module (like `debug`) to provide control over when messages are logged; so I used the `webpack.ProvidePlugin` to make it a global.

I also remembered that the entire `package.json` was being required, so I look at it, saw that it only needed the `version` key, and used `ProvidePlugin` to expose that as a `VERSION` global.

Fun times!

[1]: `source-map-explorer build/gobbldygook.3.0.0-beta3.js build/gobbldygook.3.0.0-beta3.js.map`