### PR TITLE
Add the ability to have requirements not share a dirty list

### DIFF
--- a/area-data/majors/mathematics.yaml
+++ b/area-data/majors/mathematics.yaml
@@ -6,6 +6,7 @@ result:
     seven courses from (Transitions, Perspectives, Level III, Sequence, Electives) &
     at most two courses from children where { department != MATH }
 
+children share courses: true
 
 Basic:
     Calculus I: MATH 120
@@ -21,6 +22,7 @@ Transitions:
 
 Perspectives:
     description: One course from each of three of the four perspectives.
+    children share courses: false
 
     Axiomatic/Algebraic (A): one of (MATH 252, 352, 356)
     Continuous/Analytic (C): one of (MATH  230, 244, 226, 262, 340, 344)

--- a/src/area-tools/enhance-hanson.js
+++ b/src/area-tools/enhance-hanson.js
@@ -18,7 +18,7 @@ const quote = str => `"${str}"`
 
 let declaredVariables = {}
 
-const baseWhitelist = ['result', 'message', 'declare']
+const baseWhitelist = ['result', 'message', 'declare', 'children share courses']
 const topLevelWhitelist = baseWhitelist.concat(['name', 'revision', 'type', 'sourcePath', 'slug', 'source', 'dateAdded', 'available through', '_error'])
 const lowerLevelWhitelist = baseWhitelist.concat(['filter', 'message', 'description', 'student selected'])
 


### PR DESCRIPTION
Primarily for the math major: if a requirement is set to `children share courses = true`, then they share courses. The default is false (well, undefined).

If they don't share courses, then they share the dirty set; if they do, however, they each receive their own dirty set, so that they don't know if a course has been used yet or not.

`children share courses` is non-recursive.