### PR TITLE
Show scheduling issues again

### DIFF
--- a/src/components/inline-course.js
+++ b/src/components/inline-course.js
@@ -29,9 +29,6 @@ class InlineCourse extends Component {
 		studentId: PropTypes.string,
 	};
 
-	static defaultProps = {
-		conflicts: [],
-	};
 	props: {
 		className?: string,
 		conflicts?: Object[],
@@ -65,7 +62,7 @@ class InlineCourse extends Component {
 	};
 
 	render() {
-		const { course, conflicts, index, scheduleId, studentId } = this.props
+		const { course, conflicts=[], index, scheduleId, studentId } = this.props
 		const warnings = conflicts[index || 0]
 		const hasWarnings = compact(warnings).length
 

--- a/src/components/inline-course.js
+++ b/src/components/inline-course.js
@@ -50,6 +50,7 @@ class InlineCourse extends Component {
 	shouldComponentUpdate(nextProps, nextState) {
 		return (
 			this.props.course !== nextProps.course ||
+			this.props.conflicts !== nextProps.conflicts ||
 			this.state.isOpen !== nextState.isOpen ||
 			this.props.isDragging !== nextProps.isDragging
 		)

--- a/src/components/inline-course.js
+++ b/src/components/inline-course.js
@@ -67,8 +67,8 @@ class InlineCourse extends Component {
 		const hasWarnings = compact(warnings).length
 
 		const validWarnings = filter(warnings, w => !isNull(w) && w.warning === true)
-		const warningEls = map(validWarnings, (w, index) =>
-			<li key={index}><Icon>{w.icon}</Icon> {w.msg}</li>)
+		const warningEls = map(validWarnings, (w, idx) =>
+			<li key={idx}><Icon>{w.icon}</Icon> {w.msg}</li>)
 
 		let classSet = cx(this.props.className, 'course', {
 			'expanded': this.state.isOpen,

--- a/src/components/inline-course.scss
+++ b/src/components/inline-course.scss
@@ -54,12 +54,17 @@
 	padding-bottom: 2px;
 
 	.list-item {
+		display: flex;
+		flex-flow: row wrap;
+		align-items: center;
+
 		padding: 0.125em 0.35em;
 		border-radius: 0.25em;
-		background-color: $amber-500;
-	}
-	.list-item::before {
-		margin-right: 0.35em;
+		background-color: $amber-200;
+
+		.icon {
+			margin-right: 0.35em;
+		}
 	}
 }
 

--- a/src/routes/student_content_course-table/components/course-list.scss
+++ b/src/routes/student_content_course-table/components/course-list.scss
@@ -14,7 +14,7 @@
 		outline: 0;
 	}
 
-	.list-item:last-child {
+	& > .list-item:last-child {
 		border-bottom: 0;
 	}
 }

--- a/src/routes/student_content_course-table/components/semester.js
+++ b/src/routes/student_content_course-table/components/semester.js
@@ -21,7 +21,7 @@ function Semester(props) {
 	let courseList = null
 
 	const { studentId, semester, year, canDrop, schedule } = props
-	const { courses, validation } = schedule
+	const { courses, conflicts, hasConflict } = schedule
 
 	// `recommendedCredits` is 4 for fall/spring and 1 for everything else
 	const recommendedCredits = (semester === 1 || semester === 3) ? 4 : 1
@@ -42,12 +42,12 @@ function Semester(props) {
 			availableCredits={recommendedCredits}
 			studentId={studentId}
 			schedule={schedule}
-			conflicts={validation ? validation.conflicts : []}
+			conflicts={conflicts || []}
 		/>
 	}
 
 	const className = cx('semester', {
-		invalid: validation ? validation.hasConflict : false,
+		invalid: hasConflict,
 		'can-drop': canDrop,
 	})
 


### PR DESCRIPTION
Fixes #820.

They were missing for two reasons: one, the courses weren't re-rendering when the conflicts changed, and two, a thing changed a while ago in the structure of the validation objects so no conflicts were actually being passed _to_ the courses in the first place.