### PR TITLE
Fix logging in web workers

### DIFF
--- a/modules/web/helpers/check-student-against-area.worker.js
+++ b/modules/web/helpers/check-student-against-area.worker.js
@@ -9,8 +9,8 @@ import { stringifyError } from 'modules/lib'
 import { evaluate } from 'modules/core/examine-student'
 import { getActiveStudentCourses } from './get-active-student-courses'
 import { alterCourse } from './alter-course-for-evaluation'
-import debug from 'debug'
-const log = debug('worker:check-student-against-area')
+
+const log = (...args) => console.log('worker:check-student-against-area', ...args)
 
 function tryEvaluate(student, area) {
 	try {

--- a/modules/web/helpers/load-data.worker.js
+++ b/modules/web/helpers/load-data.worker.js
@@ -24,8 +24,7 @@ import { buildDeptString, buildDeptNum } from 'modules/schools/stolaf/deptnums'
 import { splitParagraph } from 'modules/lib/split-paragraph'
 import { convertTimeStringsToOfferings } from 'sto-sis-time-parser'
 
-import debug from 'debug'
-const log = debug('worker:load-data')
+const log = (...args) => console.log('worker:load-data', ...args)
 
 
 function dispatch(type, action, ...args) {


### PR DESCRIPTION
`debug`, I think, needs to check for a property in localStorage to enable itself, but localStorage isn't present in web workers, so it's never enabled.

This switches to console.log, instead.