### PR TITLE
Remove es-modules syntax from some modules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,6 +23,7 @@ globals:
   global: false
   require: false
   process: false
+  module: false
 
   # webpack.DefinePlugin
   VERSION: false
@@ -103,7 +104,7 @@ rules:
   react/sort-prop-types: warn
   react/wrap-multilines: off
   react/prefer-stateless-function: warn
-  
+
   flowtype/space-after-type-colon: 'off'
   flowtype/space-before-type-colon: 'off'
 

--- a/modules/cli/gb
+++ b/modules/cli/gb
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-
-require('./lib/init')
-require('./gb.js').cli()

--- a/modules/cli/gb-check.js
+++ b/modules/cli/gb-check.js
@@ -1,1 +1,2 @@
-export default function check() {}
+'use strict'
+module.exports = function check() {}

--- a/modules/cli/gb-lint.js
+++ b/modules/cli/gb-lint.js
@@ -1,1 +1,2 @@
-export default function lint() {}
+'use strict'
+module.exports = function lint() {}

--- a/modules/cli/gb-search.js
+++ b/modules/cli/gb-search.js
@@ -1,5 +1,6 @@
-import table from 'text-table'
-import searchCourses from './lib/search-for-courses'
+'use strict'
+const table = require('text-table')
+const searchCourses = require('./lib/search-for-courses')
 
 function printCourse(course) {
 	return [
@@ -9,10 +10,11 @@ function printCourse(course) {
 	]
 }
 
-export default function search({ riddles, unique, sort, ...opts }={}) {
+module.exports = function search(args={}) {
+	const { riddles, unique, sort } = args
 	// check if data has been cached
 	searchCourses({ riddles, unique, sort }).then(filtered => {
-		if (opts.list) {
+		if (args.list) {
 			console.log(table(filtered.map(printCourse)))
 		}
 		else {

--- a/modules/cli/gb-update.js
+++ b/modules/cli/gb-update.js
@@ -1,6 +1,7 @@
-import { checkForStaleData } from './lib/update-local-data-cache'
+'use strict'
+const { checkForStaleData } = require('./lib/update-local-data-cache')
 
-export default function update() {
+module.exports = function update() {
 	// grab info.json
 	// apply loadData's algorithm to it
 	return checkForStaleData()

--- a/modules/cli/gb.js
+++ b/modules/cli/gb.js
@@ -1,12 +1,14 @@
-import nomnom from 'nomnom'
-import yaml from 'js-yaml'
+#!/usr/bin/env node
+'use strict'
+const nomnom = require('nomnom')
+const yaml = require('js-yaml')
 
-import update from './gb-update'
-import search from './gb-search'
-import check from './gb-check'
-import lint from './gb-lint'
+const update = require('./gb-update')
+const search = require('./gb-search')
+const check = require('./gb-check')
+const lint = require('./gb-lint')
 
-export function cli() {
+module.exports.cli = function cli() {
 	process.on('unhandledRejection', (reason, p) => {
 		console.error('Unhandled rejection in', p)
 		console.error('Reason:', reason)

--- a/modules/cli/lib/dirs.js
+++ b/modules/cli/lib/dirs.js
@@ -1,2 +1,3 @@
-import { userCacheDir } from 'appdirs'
-export const cacheDir = userCacheDir('gobbldygook')
+'use strict'
+const { userCacheDir } = require('appdirs')
+module.exports.cacheDir = userCacheDir('gobbldygook')

--- a/modules/cli/lib/find-areas.js
+++ b/modules/cli/lib/find-areas.js
@@ -1,3 +1,4 @@
+'use strict'
 const flatten = require('lodash/flatten')
 const glob = require('glob')
 const junk = require('junk')

--- a/modules/cli/lib/init.js
+++ b/modules/cli/lib/init.js
@@ -1,3 +1,4 @@
+'use strict'
 process.on('unhandledRejection', function(reason, p) {
 	console.error('Unhandled rejection in', p)
 	console.error('Reason:', reason)

--- a/modules/cli/lib/load-area.js
+++ b/modules/cli/lib/load-area.js
@@ -1,14 +1,17 @@
-import pify from 'pify'
-import yaml from 'js-yaml'
-import { enhanceHanson as enhance } from '../../hanson-format'
-import map from 'lodash/map'
-import filter from 'lodash/filter'
-import find from 'lodash/find'
-import maxBy from 'lodash/maxBy'
-import findAreas from './find-areas'
+'use strict'
+const pify = require('pify')
+const yaml = require('js-yaml')
+const { enhanceHanson: enhance } = require('../../hanson-format')
+
+const map = require('lodash/map')
+const filter = require('lodash/filter')
+const find = require('lodash/find')
+const maxBy = require('lodash/maxBy')
+
+const findAreas = require('./find-areas')
 const fs = pify(require('graceful-fs'))
 
-export async function getArea({ name, type, revision }) {
+async function getArea({ name, type, revision }) {
 	type = type.toLowerCase()
 	name = name.toLowerCase()
 
@@ -32,7 +35,7 @@ export async function getArea({ name, type, revision }) {
 	return find(filteredAreas, { revision })
 }
 
-export default async function loadArea({ name, type, revision, source, isCustom }) {
+async function loadArea({ name, type, revision, source, isCustom }) {
 	let obj = isCustom
 		? yaml.safeLoad(source)
 		: await getArea({ name, type, revision })
@@ -48,3 +51,6 @@ export default async function loadArea({ name, type, revision, source, isCustom 
 
 	return result
 }
+
+module.exports = loadArea
+module.exports.getArea = getArea

--- a/modules/cli/lib/load-student.js
+++ b/modules/cli/lib/load-student.js
@@ -1,8 +1,9 @@
-import loadArea from './load-area'
-import { readFileSync } from 'graceful-fs'
-import yaml from 'js-yaml'
+'use strict'
+const loadArea = require('./load-area')
+const { readFileSync } = require('graceful-fs')
+const yaml = require('js-yaml')
 
-export default async function loadStudent(filename, { isFile=true }={}) {
+module.exports = async function loadStudent(filename, { isFile=true }={}) {
 	let contents
 	if (isFile) {
 		contents = readFileSync(filename, 'utf-8')

--- a/modules/cli/lib/populate-courses.js
+++ b/modules/cli/lib/populate-courses.js
@@ -1,13 +1,14 @@
-import flatten from 'lodash/flatten'
-import includes from 'lodash/includes'
+'use strict'
+const flatten = require('lodash/flatten')
+const includes = require('lodash/includes')
 
-import searchForCourses from './search-for-courses'
+const searchForCourses = require('./search-for-courses')
 
-export function getCoursesByClbid(clbids) {
+function getCoursesByClbid(clbids) {
 	return searchForCourses({ riddles: [course => includes(clbids, course.clbid)] })
 }
 
-export default async function populateCourses(student) {
+async function populateCourses(student) {
 	const clbids = student.clbids || flatten(student.schedules.filter(s => s.active).map(s => s.clbids))
 	let courses = await getCoursesByClbid(clbids)
 	courses = courses.map(c => {
@@ -16,3 +17,6 @@ export default async function populateCourses(student) {
 	})
 	return courses
 }
+
+module.exports = populateCourses
+module.exports.getCoursesByClbid = getCoursesByClbid

--- a/modules/cli/lib/read-file.js
+++ b/modules/cli/lib/read-file.js
@@ -1,31 +1,36 @@
-import 'whatwg-fetch'
-import { status, json, text } from '../../lib/fetch-helpers'
+'use strict'
+require('whatwg-fetch')
+const { status, json, text } = require('../../lib/fetch-helpers')
 
-import startsWith from 'lodash/startsWith'
-import yaml from 'js-yaml'
-import pify from 'pify'
+const startsWith = require('lodash/startsWith')
+const yaml = require('js-yaml')
+const pify = require('pify')
 
 const fs = pify(require('graceful-fs'))
 
-export function loadFile(pathOrUrl) {
+module.exports.loadFile = loadFile
+function loadFile(pathOrUrl) {
 	return startsWith(pathOrUrl, 'http')
 		? fetch(pathOrUrl).then(status).then(text)
 		: fs.readFileAsync(pathOrUrl, { encoding: 'utf-8' })
 }
 
-export function loadJsonFile(pathOrUrl) {
+module.exports.loadJsonFile = loadJsonFile
+function loadJsonFile(pathOrUrl) {
 	return startsWith(pathOrUrl, 'http')
 		? fetch(pathOrUrl).then(status).then(json)
 		: fs.readFileAsync(pathOrUrl, { encoding: 'utf-8' }).then(JSON.parse)
 }
 
-export function loadYamlFile(pathOrUrl) {
+module.exports.loadYamlFile = loadYamlFile
+function loadYamlFile(pathOrUrl) {
 	return startsWith(pathOrUrl, 'http')
 		? fetch(pathOrUrl).then(status).then(text).then(yaml.safeLoad)
 		: fs.readFileAsync(pathOrUrl, { encoding: 'utf-8' }).then(yaml.safeLoad)
 }
 
-export function tryReadFile(path) {
+module.exports.tryReadFile = tryReadFile
+function tryReadFile(path) {
 	try {
 		return fs.readFileSync(path, { encoding: 'utf-8' })
 	} catch (err) {} // eslint-disable-line brace-style, no-empty
@@ -33,7 +38,8 @@ export function tryReadFile(path) {
 	return false
 }
 
-export function tryReadJsonFile(path) {
+module.exports.tryReadJsonFile = tryReadJsonFile
+function tryReadJsonFile(path) {
 	try {
 		return JSON.parse(fs.readFileSync(path, { encoding: 'utf-8' }))
 	} catch (err) {} // eslint-disable-line brace-style, no-empty

--- a/modules/cli/lib/search-for-courses.js
+++ b/modules/cli/lib/search-for-courses.js
@@ -1,22 +1,23 @@
-import { tryReadJsonFile } from './read-file'
+'use strict'
+const { tryReadJsonFile } = require('./read-file')
 
-import flatten from 'lodash/flatten'
-import filter from 'lodash/filter'
-import forEach from 'lodash/forEach'
-import uniqBy from 'lodash/uniqBy'
-import isString from 'lodash/isString'
-import sortBy from 'lodash/sortBy'
-import map from 'lodash/map'
+const flatten = require('lodash/flatten')
+const filter = require('lodash/filter')
+const forEach = require('lodash/forEach')
+const uniqBy = require('lodash/uniqBy')
+const isString = require('lodash/isString')
+const sortBy = require('lodash/sortBy')
+const map = require('lodash/map')
 
-import { cacheDir } from './dirs'
+const { cacheDir } = require('./dirs')
 
-import { checkForStaleData } from './update-local-data-cache'
+const { checkForStaleData } = require('./update-local-data-cache')
 
-import path from 'path'
+const path = require('path')
 
-import { quacksLikeDeptNum, splitDeptNum } from '../../school-st-olaf-college'
+const { quacksLikeDeptNum, splitDeptNum } = require('../../school-st-olaf-college')
 
-import pify from 'pify'
+const pify = require('pify')
 const fs = pify(require('graceful-fs'))
 
 function getDeptNumsFromRiddles(r) {
@@ -26,7 +27,7 @@ function getDeptNumsFromRiddles(r) {
 	return r
 }
 
-export default async function search({ riddles, unique, sort }={}) {
+module.exports = async function search({ riddles, unique, sort }={}) {
 	// check if data has been cached
 	await checkForStaleData()
 

--- a/modules/cli/lib/update-local-data-cache.js
+++ b/modules/cli/lib/update-local-data-cache.js
@@ -1,17 +1,18 @@
-import mkdirp from 'mkdirp'
-import find from 'lodash/find'
-import some from 'lodash/some'
-import startsWith from 'lodash/startsWith'
-import path from 'path'
+'use strict'
+const mkdirp = require('mkdirp')
+const find = require('lodash/find')
+const some = require('lodash/some')
+const startsWith = require('lodash/startsWith')
+const path = require('path')
 
-import {
+const {
 	tryReadJsonFile,
 	loadFile,
 	loadJsonFile,
-} from './read-file'
-import { cacheDir } from './dirs'
+} = require('./read-file')
+const { cacheDir } = require('./dirs')
 
-import pify from 'pify'
+const pify = require('pify')
 
 const fs = pify(require('graceful-fs'))
 
@@ -26,7 +27,8 @@ function prepareDirs() {
 	mkdirp.sync(`${cacheDir}/Areas of Study/`)
 }
 
-export async function cache() {
+module.exports.cache = cache
+async function cache() {
 	prepareDirs()
 
 	const priorCourseInfo = tryReadJsonFile(`${cacheDir}/Courses/info.prior.json`) || {}
@@ -53,11 +55,10 @@ export async function cache() {
 				fullPath = `https://${fullPath}`
 			}
 
-			return {
-				...file,
+			return Object.assign({}, file, {
 				fullPath,
 				data: loadFile(fullPath),
-			}
+			})
 		})
 
 
@@ -75,7 +76,8 @@ export async function cache() {
 	return Promise.all([courseInfo])
 }
 
-export async function checkForStaleData() {
+module.exports.checkForStaleData = checkForStaleData
+async function checkForStaleData() {
 	prepareDirs()
 
 	const newCourseInfo = await loadJsonFile(COURSE_INFO_LOCATION)

--- a/modules/hanson-format/convert-department.js
+++ b/modules/hanson-format/convert-department.js
@@ -1,5 +1,6 @@
 // @flow
-import forEach from 'lodash/forEach'
+'use strict'
+const forEach = require('lodash/forEach')
 
 const shortDepartmentAbbreviationsToFullDepartmentAbbreviations = {
 	AR: 'ART',
@@ -88,8 +89,8 @@ const fullDepartmentNamesToFullDepartmentAbbreviations = {
 	'STATISTICS': 'STAT',
 	'THEATER': 'THEAT',
 	'UNKNOWN DEPARTMENT': 'NONE',
-	'WOMEN\'S AND GENDER STUDIES': 'WMGST',
-	'WOMEN\'S STUDIES': 'WMGST',
+	"WOMEN'S AND GENDER STUDIES": 'WMGST',
+	"WOMEN'S STUDIES": 'WMGST',
 	'WOMENS AND GENDER STUDIES': 'WMGST',
 	'WOMENS STUDIES': 'WMGST',
 	'WRI': 'WRIT',
@@ -218,15 +219,14 @@ const courseTypesMapping = {
 }
 
 
-const toDepartmentAbbreviations = {
-	...shortDepartmentAbbreviationsToFullDepartmentAbbreviations,
-	...fullDepartmentNamesToFullDepartmentAbbreviations,
-}
-const toDepartmentNames = {
-	...departmentAbbreviationsToNames,
-}
+const toDepartmentAbbreviations = Object.assign({},
+	shortDepartmentAbbreviationsToFullDepartmentAbbreviations,
+	fullDepartmentNamesToFullDepartmentAbbreviations)
+const toDepartmentNames = Object.assign({},
+	departmentAbbreviationsToNames)
 
-export function expandDepartment(dept: string) {
+module.exports.expandDepartment = expandDepartment
+function expandDepartment(dept: string) {
 	dept = dept.toUpperCase()
 	if (!(dept in toDepartmentNames)) {
 		throw new TypeError(`expandDepartment(): '${dept}' is not a valid department shorthand`)
@@ -234,7 +234,8 @@ export function expandDepartment(dept: string) {
 	return toDepartmentNames[dept]
 }
 
-export function normalizeDepartment(dept: string) {
+module.exports.normalizeDepartment = normalizeDepartment
+function normalizeDepartment(dept: string) {
 	dept = dept.toUpperCase()
 	if (!(dept in toDepartmentAbbreviations)) {
 		return dept

--- a/modules/hanson-format/enhance-hanson.js
+++ b/modules/hanson-format/enhance-hanson.js
@@ -1,16 +1,17 @@
 // @flow
-import isRequirementName from '../examine-student/is-requirement-name'
-import filter from 'lodash/filter'
-import forEach from 'lodash/forEach'
-import includes from 'lodash/includes'
-import isString from 'lodash/isString'
-import keys from 'lodash/keys'
-import map from 'lodash/map'
-import mapValues from 'lodash/mapValues'
-import some from 'lodash/some'
-import fromPairs from 'lodash/fromPairs'
-import { makeAreaSlug } from './make-area-slug'
-import { parse } from './parse-hanson-string'
+'use strict'
+const { default: isRequirementName } = require('../examine-student/is-requirement-name')
+const filter = require('lodash/filter')
+const forEach = require('lodash/forEach')
+const includes = require('lodash/includes')
+const isString = require('lodash/isString')
+const keys = require('lodash/keys')
+const map = require('lodash/map')
+const mapValues = require('lodash/mapValues')
+const some = require('lodash/some')
+const fromPairs = require('lodash/fromPairs')
+const { makeAreaSlug } = require('./make-area-slug')
+const { parse } = require('./parse-hanson-string')
 
 const requirementNameRegex = /(.*?) +\(([A-Z\-]+)\)$/i
 const none = (arr, pred) => !some(arr, pred)
@@ -28,7 +29,8 @@ const startRules = {
 
 type StringMap = {[key: string]: string};
 
-export function enhanceHanson(data: any, { topLevel=true, declaredVariables={} }: {topLevel: boolean, declaredVariables: StringMap}={}) {
+module.exports.enhanceHanson = enhanceHanson
+function enhanceHanson(data: any, { topLevel=true, declaredVariables={} }: {topLevel: boolean, declaredVariables: StringMap}={}) {
 	// 1. adds 'result' key, if missing
 	// 2. parses the 'result' and 'filter' keys
 	// 3. throws if it encounters any lowercase keys not in the whitelist

--- a/modules/hanson-format/index.js
+++ b/modules/hanson-format/index.js
@@ -1,5 +1,13 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export { expandDepartment, normalizeDepartment } from './convert-department'
-export { enhanceHanson } from './enhance-hanson'
-export { makeAreaSlug } from './make-area-slug'
-export { parse } from './parse-hanson-string'
+'use strict'
+const { expandDepartment, normalizeDepartment } = require('./convert-department')
+const { enhanceHanson } = require('./enhance-hanson')
+const { makeAreaSlug } = require('./make-area-slug')
+const { parse } = require('./parse-hanson-string')
+
+module.exports = {
+	expandDepartment,
+	normalizeDepartment,
+	enhanceHanson,
+	makeAreaSlug,
+	parse,
+}

--- a/modules/hanson-format/make-area-slug.js
+++ b/modules/hanson-format/make-area-slug.js
@@ -1,6 +1,9 @@
 // @flow
-import kebabCase from 'lodash/kebabCase'
+'use strict'
+const kebabCase = require('lodash/kebabCase')
 
-export function makeAreaSlug(name: string): string {
+function makeAreaSlug(name: string): string {
 	return kebabCase((name || '').replace("'", '')).toLowerCase()
 }
+
+module.exports.makeAreaSlug = makeAreaSlug

--- a/modules/lib/compare-props.js
+++ b/modules/lib/compare-props.js
@@ -1,6 +1,9 @@
 // @flow
-import every from 'lodash/every'
+'use strict'
+const every = require('lodash/every')
 
-export function compareProps(oldProps: Object, newProps: Object): boolean {
+function compareProps(oldProps: Object, newProps: Object): boolean {
 	return !every(oldProps, (_, key) => oldProps[key] === newProps[key])
 }
+
+module.exports.compareProps = compareProps

--- a/modules/lib/errors.js
+++ b/modules/lib/errors.js
@@ -1,3 +1,5 @@
 // @flow
-export class AuthError extends Error {}
-export class NetworkError extends Error {}
+'use strict'
+
+module.exports.AuthError = class AuthError extends Error {}
+module.exports.NetworkError = class NetworkError extends Error {}

--- a/modules/lib/fetch-helpers.js
+++ b/modules/lib/fetch-helpers.js
@@ -1,7 +1,9 @@
 // @flow
-import { NetworkError } from './errors'
+'use strict'
+const { NetworkError } = require('./errors')
 
-export function status(response: Response) {
+module.exports.status = status
+function status(response /*: Response*/) {
 	if (response.status >= 200 && response.status < 300) {
 		return response
 	}
@@ -9,16 +11,19 @@ export function status(response: Response) {
 	throw new Error(response.statusText)
 }
 
-export function classifyFetchErrors(err: Error) {
+module.exports.classifyFetchErrors = classifyFetchErrors
+function classifyFetchErrors(err /*: Error*/) {
 	if (err instanceof TypeError && err.message === 'Failed to fetch') {
 		throw new NetworkError('Failed to fetch')
 	}
 }
 
-export function json(response: Response) {
+module.exports.json = json
+function json(response /*: Response*/) {
 	return response.json()
 }
 
-export function text(response: Response) {
+module.exports.text = text
+function text(response /*: Response*/) {
 	return response.text()
 }

--- a/modules/lib/find-missing-number-binary-search.js
+++ b/modules/lib/find-missing-number-binary-search.js
@@ -1,6 +1,7 @@
 // @flow
+'use strict'
 // via http://stackoverflow.com/questions/11385896/find-the-first-missing-number-in-a-sorted-list
-export function findMissingNumberBinarySearch(arr: number[]): ?number {
+function findMissingNumberBinarySearch(arr: number[]): ?number {
 	let first = 0
 	let last = arr.length - 1
 	let middle = Math.floor((first + last) / 2)
@@ -32,3 +33,5 @@ export function findMissingNumberBinarySearch(arr: number[]): ?number {
 	// there is no hole
 	return null
 }
+
+module.exports.findMissingNumberBinarySearch = findMissingNumberBinarySearch

--- a/modules/lib/find-word-for-progress.js
+++ b/modules/lib/find-word-for-progress.js
@@ -1,5 +1,7 @@
 // @flow
-export function findWordForProgress(maxProgress: number, currentProgress: number): string {
+'use strict'
+
+function findWordForProgress(maxProgress: number, currentProgress: number): string {
 	const progress = currentProgress / maxProgress
 
 	if (progress >= 1) {
@@ -38,3 +40,5 @@ export function findWordForProgress(maxProgress: number, currentProgress: number
 
 	return 'zero'
 }
+
+module.exports.findWordForProgress = findWordForProgress

--- a/modules/lib/index.js
+++ b/modules/lib/index.js
@@ -1,13 +1,32 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export { compareProps } from './compare-props'
-export { AuthError, NetworkError } from './errors'
-export { status, classifyFetchErrors, json, text } from './fetch-helpers'
-export { findMissingNumberBinarySearch } from './find-missing-number-binary-search'
-export { findWordForProgress } from './find-word-for-progress'
-export { interpose } from './interpose'
-export { partitionByIndex } from './partition-by-index'
-export { randomChar } from './random-char'
-export { splitParagraph } from './split-paragraph'
-export { stringifyError } from './stringify-error'
-export { to12HourTime } from './to-12-hour-time'
-export { zipToObjectWithArrays } from './zip-to-object-with-arrays'
+'use strict'
+const { compareProps } = require('./compare-props')
+const { AuthError, NetworkError } = require('./errors')
+const { status, classifyFetchErrors, json, text } = require('./fetch-helpers')
+const { findMissingNumberBinarySearch } = require('./find-missing-number-binary-search')
+const { findWordForProgress } = require('./find-word-for-progress')
+const { interpose } = require('./interpose')
+const { partitionByIndex } = require('./partition-by-index')
+const { randomChar } = require('./random-char')
+const { splitParagraph } = require('./split-paragraph')
+const { stringifyError } = require('./stringify-error')
+const { to12HourTime } = require('./to-12-hour-time')
+const { zipToObjectWithArrays } = require('./zip-to-object-with-arrays')
+
+module.exports = {
+	compareProps,
+	AuthError,
+	NetworkError,
+	status,
+	classifyFetchErrors,
+	json,
+	text,
+	findMissingNumberBinarySearch,
+	findWordForProgress,
+	interpose,
+	partitionByIndex,
+	randomChar,
+	splitParagraph,
+	stringifyError,
+	to12HourTime,
+	zipToObjectWithArrays,
+}

--- a/modules/lib/interpose.js
+++ b/modules/lib/interpose.js
@@ -1,7 +1,8 @@
 // @flow
-import reduce from 'lodash/reduce'
+'use strict'
+const reduce = require('lodash/reduce')
 
-export function interpose<T, U>(data: T[], value: U): (T | U)[] {
+function interpose<T, U>(data: T[], value: U): (T | U)[] {
 	const len = data.length
 	return reduce(data, (arr, item, index) => {
 		if (index < len - 1) {
@@ -10,3 +11,5 @@ export function interpose<T, U>(data: T[], value: U): (T | U)[] {
 		return arr.concat(item)
 	}, [])
 }
+
+module.exports.interpose = interpose

--- a/modules/lib/partition-by-index.js
+++ b/modules/lib/partition-by-index.js
@@ -1,10 +1,13 @@
 // @flow
-import reduce from 'lodash/reduce'
+'use strict'
+const reduce = require('lodash/reduce')
 
-export function partitionByIndex<T>(arr: T[]): [T[], T[]] {
+function partitionByIndex<T>(arr: T[]): [T[], T[]] {
 	return reduce(arr, (acc, val, idx) => {
 		return idx % 2 === 0
 			? [acc[0].concat(val), acc[1]]
 			: [acc[0], acc[1].concat(val)]
 	}, [[], []])
 }
+
+module.exports.partitionByIndex = partitionByIndex

--- a/modules/lib/random-char.js
+++ b/modules/lib/random-char.js
@@ -1,9 +1,13 @@
+'use strict'
+
 /**
  * @flow
  * A function to return a random character, modified from
  * stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
  */
 
-export function randomChar(): string {
+function randomChar(): string {
 	return Math.random().toString(36).slice(2, 3)
 }
+
+module.exports.randomChar = randomChar

--- a/modules/lib/split-paragraph.js
+++ b/modules/lib/split-paragraph.js
@@ -1,8 +1,9 @@
 // @flow
-import words from 'lodash/words'
-import deburr from 'lodash/deburr'
+'use strict'
+const words = require('lodash/words')
+const deburr = require('lodash/deburr')
 
-export function splitParagraph(string: string=''): string {
+function splitParagraph(string: string=''): string {
 	let lowercase = string.toLowerCase()
 
 	// removes accents and such from ascii chars
@@ -11,3 +12,5 @@ export function splitParagraph(string: string=''): string {
 	// returns just the words, stripping extra spaces and symbols
 	return words(noAccents)
 }
+
+module.exports.splitParagraph = splitParagraph

--- a/modules/lib/stringify-error.js
+++ b/modules/lib/stringify-error.js
@@ -1,8 +1,12 @@
 // @flow
-export function stringifyError(err: any, filter?: (Array<any> | (key: any, value: any) => any), space?: string | number) {
+'use strict'
+
+function stringifyError(err: any, filter?: (Array<any> | (key: any, value: any) => any), space?: string | number) {
 	let plainObject = {}
 	Object.getOwnPropertyNames(err).forEach(key => {
 		plainObject[key] = err[key]
 	})
 	return JSON.stringify(plainObject, filter, space)
 }
+
+module.exports.stringifyError = stringifyError

--- a/modules/lib/to-12-hour-time.js
+++ b/modules/lib/to-12-hour-time.js
@@ -1,5 +1,6 @@
 // @flow
-import padStart from 'lodash/padStart'
+'use strict'
+const padStart = require('lodash/padStart')
 
 function split24HourTime(time) {
 	time = padStart(time, 4, '0')
@@ -9,7 +10,7 @@ function split24HourTime(time) {
 	}
 }
 
-export function to12HourTime(time: string): string {
+function to12HourTime(time: string): string {
 	const { hour, minute } = split24HourTime(time)
 	const paddedMinute = padStart(minute, 2, '0')
 
@@ -18,3 +19,5 @@ export function to12HourTime(time: string): string {
 
 	return `${fullHour}:${paddedMinute}${meridian}`
 }
+
+module.exports.to12HourTime = to12HourTime

--- a/modules/lib/zip-to-object-with-arrays.js
+++ b/modules/lib/zip-to-object-with-arrays.js
@@ -1,9 +1,10 @@
 // @flow
-import reduce from 'lodash/reduce'
-import zip from 'lodash/zip'
-import has from 'lodash/has'
+'use strict'
+const reduce = require('lodash/reduce')
+const zip = require('lodash/zip')
+const has = require('lodash/has')
 
-export function zipToObjectWithArrays<T>(keys: string[], vals: T[]): {[key: string]: Array<T>} {
+function zipToObjectWithArrays<T>(keys: string[], vals: T[]): {[key: string]: Array<T>} {
 	let arr = zip(keys, vals)
 
 	return reduce(arr, (obj, [key, val]) => {
@@ -17,3 +18,5 @@ export function zipToObjectWithArrays<T>(keys: string[], vals: T[]): {[key: stri
 		return obj
 	}, {})
 }
+
+module.exports.zipToObjectWithArrays = zipToObjectWithArrays

--- a/modules/object-student/area-types.js
+++ b/modules/object-student/area-types.js
@@ -1,4 +1,5 @@
-export const areaTypeConstants = {
+'use strict'
+module.exports.areaTypeConstants = {
 	DEGREE: 'degree',
 	MAJOR: 'major',
 	CONCENTRATION: 'concentration',

--- a/modules/object-student/encode-student.js
+++ b/modules/object-student/encode-student.js
@@ -1,14 +1,17 @@
-import stringify from 'stabilize'
-import omit from 'lodash/omit'
-import mapValues from 'lodash/mapValues'
+'use strict'
+const stringify = require('stabilize')
+const omit = require('lodash/omit')
+const mapValues = require('lodash/mapValues')
 
-export function prepareStudentForSave(student) {
-	student = { ...student }
+module.exports.prepareStudentForSave = prepareStudentForSave
+function prepareStudentForSave(student) {
+	student = Object.assign({}, student)
 	student = omit(student, ['areas', 'canGraduate', 'fulfilled'])
 	student.schedules = mapValues(student.schedules, s => omit(s, ['courses', 'conflicts', 'hasConflict']))
 	return student
 }
 
-export function encodeStudent(student) {
+module.exports.encodeStudent = encodeStudent
+function encodeStudent(student) {
 	return encodeURIComponent(stringify(prepareStudentForSave(student)))
 }

--- a/modules/object-student/filter-area-list.js
+++ b/modules/object-student/filter-area-list.js
@@ -1,9 +1,10 @@
-import reject from 'lodash/reject'
-import groupBy from 'lodash/groupBy'
-import flatten from 'lodash/flatten'
-import map from 'lodash/map'
-import filter from 'lodash/filter'
-import sortBy from 'lodash/sortBy'
+'use strict'
+const reject = require('lodash/reject')
+const groupBy = require('lodash/groupBy')
+const flatten = require('lodash/flatten')
+const map = require('lodash/map')
+const filter = require('lodash/filter')
+const sortBy = require('lodash/sortBy')
 
 function convertRevisionToYear(rev) {
 	// The +1 is because the year is the beginning of the academic year, but
@@ -26,7 +27,7 @@ function convertRevisionToYear(rev) {
 // You can only enroll in a major if there isn't a newer one, unless your
 // class year is between the previous one and the newest.
 
-export function filterAreaList(areas, { graduation }) {
+function filterAreaList(areas, { graduation }) {
 	// Remove all areas that are closed to new class years.
 	let onlyAvailableAreas = reject(areas,
 		area => area['available through'] && area['available through'] <= graduation)
@@ -70,3 +71,5 @@ export function filterAreaList(areas, { graduation }) {
 
 	return onlyAvailableAreas
 }
+
+module.exports.filterAreaList = filterAreaList

--- a/modules/object-student/find-course-warnings.js
+++ b/modules/object-student/find-course-warnings.js
@@ -1,17 +1,19 @@
-import map from 'lodash/map'
-import flatten from 'lodash/flatten'
-import compact from 'lodash/compact'
-import some from 'lodash/some'
-import zip from 'lodash/zip'
+'use strict'
+const map = require('lodash/map')
+const flatten = require('lodash/flatten')
+const compact = require('lodash/compact')
+const some = require('lodash/some')
+const zip = require('lodash/zip')
 
-import ordinal from 'ord'
-import oxford from 'listify'
-import plur from 'plur'
-import { findScheduleTimeConflicts } from 'sto-sis-time-parser'
-import { expandYear, semesterName } from '../school-st-olaf-college/course-info'
+const ordinal = require('ord')
+const oxford = require('listify')
+const plur = require('plur')
+const { findScheduleTimeConflicts } = require('sto-sis-time-parser')
+const { expandYear, semesterName } = require('../school-st-olaf-college/course-info')
 // import {alertCircled, iosCalendarOutline, iosClockOutline} from '../web/icons/ionicons'
 
-export function checkForInvalidYear(course, scheduleYear) {
+module.exports.checkForInvalidYear = checkForInvalidYear
+function checkForInvalidYear(course, scheduleYear) {
 	let thisYear = new Date().getFullYear()
 
 	if (course.year !== scheduleYear && scheduleYear <= thisYear) {
@@ -26,7 +28,8 @@ export function checkForInvalidYear(course, scheduleYear) {
 	return null
 }
 
-export function checkForInvalidSemester(course, scheduleSemester) {
+module.exports.checkForInvalidSemester = checkForInvalidSemester
+function checkForInvalidSemester(course, scheduleSemester) {
 	if (course.semester !== scheduleSemester) {
 		return {
 			warning: true,
@@ -39,7 +42,8 @@ export function checkForInvalidSemester(course, scheduleSemester) {
 	return null
 }
 
-export function checkForTimeConflicts(courses) {
+module.exports.checkForTimeConflicts = checkForTimeConflicts
+function checkForTimeConflicts(courses) {
 	let conflicts = findScheduleTimeConflicts(courses)
 
 	conflicts = map(conflicts, conflictSet => {
@@ -62,7 +66,8 @@ export function checkForTimeConflicts(courses) {
 	return conflicts
 }
 
-export function findWarnings(courses, schedule) {
+module.exports.findWarnings = findWarnings
+function findWarnings(courses, schedule) {
 	let warningsOfInvalidity = map(courses, course => {
 		let invalidYear = checkForInvalidYear(course, schedule.year)
 		let invalidSemester = checkForInvalidSemester(course, schedule.semester)

--- a/modules/object-student/index.js
+++ b/modules/object-student/index.js
@@ -1,33 +1,33 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
+'use strict'
 
-export { areaTypeConstants } from './area-types'
+const { areaTypeConstants } = require('./area-types')
 
-export { encodeStudent, prepareStudentForSave } from './encode-student'
+const { encodeStudent, prepareStudentForSave } = require('./encode-student')
 
-export { filterAreaList } from './filter-area-list'
+const { filterAreaList } = require('./filter-area-list')
 
-export {
+const {
 	findWarnings,
 	checkForInvalidYear,
 	checkForInvalidSemester,
 	checkForTimeConflicts,
-} from './find-course-warnings'
+} = require('./find-course-warnings')
 
-export { isCurrentSemester } from './is-current-semester'
+const { isCurrentSemester } = require('./is-current-semester')
 
-export {
+const {
 	IDENT_COURSE,
 	IDENT_AREA,
 	IDENT_YEAR,
 	IDENT_SEMESTER,
 	IDENT_SCHEDULE,
-} from './item-types'
+} = require('./item-types')
 
-export { Schedule } from './schedule'
+const { Schedule } = require('./schedule')
 
-export { sortStudiesByType } from './sort-studies-by-type'
+const { sortStudiesByType } = require('./sort-studies-by-type')
 
-export {
+const {
 	Student,
 	changeStudentName,
 	changeStudentAdvisor,
@@ -50,8 +50,51 @@ export {
 	reorderScheduleInStudent,
 	renameScheduleInStudent,
 	reorderCourseInSchedule,
-} from './student'
+} = require('./student')
 
-export { validateSchedule } from './validate-schedule'
+const { validateSchedule } = require('./validate-schedule')
 
-export { validateSchedules } from './validate-schedules'
+const { validateSchedules } = require('./validate-schedules')
+
+module.exports = {
+	areaTypeConstants,
+	encodeStudent,
+	prepareStudentForSave,
+	filterAreaList,
+	findWarnings,
+	checkForInvalidYear,
+	checkForInvalidSemester,
+	checkForTimeConflicts,
+	isCurrentSemester,
+	Schedule,
+	sortStudiesByType,
+	IDENT_COURSE,
+	IDENT_AREA,
+	IDENT_YEAR,
+	IDENT_SEMESTER,
+	IDENT_SCHEDULE,
+	validateSchedule,
+	validateSchedules,
+	Student,
+	changeStudentName,
+	changeStudentAdvisor,
+	changeStudentCreditsNeeded,
+	changeStudentMatriculation,
+	changeStudentGraduation,
+	changeStudentSetting,
+	addScheduleToStudent,
+	destroyScheduleFromStudent,
+	addCourseToSchedule,
+	removeCourseFromSchedule,
+	moveCourseToSchedule,
+	addAreaToStudent,
+	removeAreaFromStudent,
+	setOverrideOnStudent,
+	removeOverrideFromStudent,
+	addFabricationToStudent,
+	removeFabricationFromStudent,
+	moveScheduleInStudent,
+	reorderScheduleInStudent,
+	renameScheduleInStudent,
+	reorderCourseInSchedule,
+}

--- a/modules/object-student/is-current-semester.js
+++ b/modules/object-student/is-current-semester.js
@@ -1,3 +1,4 @@
+'use strict'
 /**
  * Checks if a schedule is in a certain year and semester.
  *
@@ -5,6 +6,8 @@
  * @param {Number} semester - a semester
  * @returns {Boolean} - is the schedule part of the current semester
  */
-export function isCurrentSemester(year, semester) {
+function isCurrentSemester(year, semester) {
 	return schedule => (schedule.year === year) && (schedule.semester === semester)
 }
+
+module.exports.isCurrentSemester = isCurrentSemester

--- a/modules/object-student/item-types.js
+++ b/modules/object-student/item-types.js
@@ -1,5 +1,10 @@
-export const IDENT_COURSE = 'gobbldygook/dnd/course'
-export const IDENT_AREA = 'gobbldygook/dnd/area'
-export const IDENT_YEAR = 'gobbldygook/dnd/year'
-export const IDENT_SEMESTER = 'gobbldygook/dnd/semester'
-export const IDENT_SCHEDULE = 'gobbldygook/dnd/schedule'
+// @flow
+'use strict'
+
+module.exports = {
+	IDENT_COURSE: 'gobbldygook/dnd/course',
+	IDENT_AREA: 'gobbldygook/dnd/area',
+	IDENT_YEAR: 'gobbldygook/dnd/year',
+	IDENT_SEMESTER: 'gobbldygook/dnd/semester',
+	IDENT_SCHEDULE: 'gobbldygook/dnd/schedule',
+}

--- a/modules/object-student/schedule.js
+++ b/modules/object-student/schedule.js
@@ -1,9 +1,10 @@
-import isString from 'lodash/isString'
-import uuid from 'uuid/v4'
+'use strict'
+const isString = require('lodash/isString')
+const uuid = require('uuid/v4')
 
-import { randomChar } from '../lib/random-char'
+const { randomChar } = require('../lib/random-char')
 
-export function Schedule(data={}) {
+function Schedule(data={}) {
 	const baseSchedule = {
 		id: uuid(),
 		active: false,
@@ -18,10 +19,9 @@ export function Schedule(data={}) {
 		metadata: {},
 	}
 
-	let schedule = {
-		...baseSchedule,
-		...data,
-	}
+	let schedule = Object.assign({},
+		baseSchedule,
+		data)
 
 	if (!isString(schedule.id)) {
 		throw new TypeError('Schedule id must be a string.')
@@ -37,3 +37,5 @@ export function Schedule(data={}) {
 
 	return schedule
 }
+
+module.exports.Schedule = Schedule

--- a/modules/object-student/sort-studies-by-type.js
+++ b/modules/object-student/sort-studies-by-type.js
@@ -1,6 +1,10 @@
-import sortBy from 'lodash/sortBy'
+// @flow
+'use strict'
+const sortBy = require('lodash/sortBy')
 
 const types = ['degree', 'major', 'concentration', 'emphasis']
-export function sortStudiesByType(studies) {
+function sortStudiesByType(studies: string[]) {
 	return sortBy(studies, s => types.indexOf(s.type))
 }
+
+module.exports.sortStudiesByType = sortStudiesByType

--- a/modules/object-student/student.js
+++ b/modules/object-student/student.js
@@ -1,25 +1,27 @@
-import clone from 'lodash/clone'
-import findIndex from 'lodash/findIndex'
-import findKey from 'lodash/findKey'
-import fromPairs from 'lodash/fromPairs'
-import includes from 'lodash/includes'
-import isArray from 'lodash/isArray'
-import isNumber from 'lodash/isNumber'
-import isUndefined from 'lodash/isUndefined'
-import map from 'lodash/map'
-import mapValues from 'lodash/mapValues'
-import omit from 'lodash/omit'
-import reject from 'lodash/reject'
-import uuid from 'uuid/v4'
-import debug from 'debug'
+'use strict'
+const clone = require('lodash/clone')
+const findIndex = require('lodash/findIndex')
+const findKey = require('lodash/findKey')
+const fromPairs = require('lodash/fromPairs')
+const includes = require('lodash/includes')
+const isArray = require('lodash/isArray')
+const isNumber = require('lodash/isNumber')
+const isUndefined = require('lodash/isUndefined')
+const map = require('lodash/map')
+const mapValues = require('lodash/mapValues')
+const omit = require('lodash/omit')
+const reject = require('lodash/reject')
+const uuid = require('uuid/v4')
+const debug = require('debug')
 const log = debug('student-format:student')
 
-import { randomChar } from '../lib/random-char'
+const { randomChar } = require('../lib/random-char')
 
 const now = new Date()
-import { Schedule } from './schedule'
+const { Schedule } = require('./schedule')
 
-export function Student(data) {
+module.exports.Student = Student
+function Student(data) {
 	const baseStudent = {
 		id: uuid(),
 		name: 'Student ' + randomChar(),
@@ -43,13 +45,13 @@ export function Student(data) {
 		settings: {},
 	}
 
-	const student = {
-		...baseStudent,
-		...data,
-	}
+	const student = Object.assign({},
+		baseStudent,
+		data)
 
 	if (isArray(student.schedules)) {
-		student.schedules = fromPairs(map(student.schedules, s => [String(s.id), { ...s, id: String(s.id) }]))
+		student.schedules = fromPairs(map(student.schedules, s =>
+			[String(s.id), Object.assign({}, s, { id: String(s.id) })]))
 	}
 
 	student.schedules = mapValues(student.schedules, Schedule)
@@ -62,53 +64,61 @@ export function Student(data) {
 ////////
 ////////
 
-export function changeStudentName(student, newName) {
+module.exports.changeStudentName = changeStudentName
+function changeStudentName(student, newName) {
 	if (student.name === newName) {
 		return student
 	}
-	return { ...student, name: newName }
+	return Object.assign({}, student, { name: newName })
 }
-export function changeStudentAdvisor(student, newAdvisor) {
+module.exports.changeStudentAdvisor = changeStudentAdvisor
+function changeStudentAdvisor(student, newAdvisor) {
 	if (student.advisor === newAdvisor) {
 		return student
 	}
-	return { ...student, advisor: newAdvisor }
+	return Object.assign({}, student, { advisor: newAdvisor })
 }
-export function changeStudentCreditsNeeded(student, newCreditsNeeded) {
+module.exports.changeStudentCreditsNeeded = changeStudentCreditsNeeded
+function changeStudentCreditsNeeded(student, newCreditsNeeded) {
 	if (student.creditsNeeded === newCreditsNeeded) {
 		return student
 	}
-	return { ...student, creditsNeeded: newCreditsNeeded }
+	return Object.assign({}, student, { creditsNeeded: newCreditsNeeded })
 }
-export function changeStudentMatriculation(student, newMatriculation) {
+module.exports.changeStudentMatriculation = changeStudentMatriculation
+function changeStudentMatriculation(student, newMatriculation) {
 	if (student.matriculation === newMatriculation) {
 		return student
 	}
-	return { ...student, matriculation: newMatriculation }
+	return Object.assign({}, student, { matriculation: newMatriculation })
 }
-export function changeStudentGraduation(student, newGraduation) {
+module.exports.changeStudentGraduation = changeStudentGraduation
+function changeStudentGraduation(student, newGraduation) {
 	if (student.graduation === newGraduation) {
 		return student
 	}
-	return { ...student, graduation: newGraduation }
+	return Object.assign({}, student, { graduation: newGraduation })
 }
-export function changeStudentSetting(student, key, value) {
+module.exports.changeStudentSetting = changeStudentSetting
+function changeStudentSetting(student, key, value) {
 	if (student.settings && student.settings[key] === value) {
 		return student
 	}
-	return { ...student, settings: { ...student.settings, [key]: value } }
+	return Object.assign({}, student, { settings: Object.assign({}, student.settings, { [key]: value }) })
 }
 
 
-export function addScheduleToStudent(student, newSchedule) {
+module.exports.addScheduleToStudent = addScheduleToStudent
+function addScheduleToStudent(student, newSchedule) {
 	if (student.schedules instanceof Array) {
 		throw new TypeError('addScheduleToStudent: schedules must not be an array!')
 	}
 
-	return { ...student, schedules: { ...student.schedules, [newSchedule.id]: newSchedule } }
+	return Object.assign({}, student, { schedules: Object.assign({}, student.schedules, { [newSchedule.id]: newSchedule }) })
 }
 
-export function destroyScheduleFromStudent(student, scheduleId) {
+module.exports.destroyScheduleFromStudent = destroyScheduleFromStudent
+function destroyScheduleFromStudent(student, scheduleId) {
 	log(`Student.destroySchedule(): removing schedule ${scheduleId}`)
 
 	if (student.schedules instanceof Array) {
@@ -130,15 +140,18 @@ export function destroyScheduleFromStudent(student, scheduleId) {
 
 		/* istanbul ignore else */
 		if (otherSchedKey) {
-			schedules[otherSchedKey] = { ...schedules[otherSchedKey], active: true }
+			schedules[otherSchedKey] = Object.assign({},
+				schedules[otherSchedKey],
+				{ active: true })
 		}
 	}
 
-	return { ...student, schedules }
+	return Object.assign({}, student, { schedules })
 }
 
 
-export function addCourseToSchedule(student, scheduleId, clbid) {
+module.exports.addCourseToSchedule = addCourseToSchedule
+function addCourseToSchedule(student, scheduleId, clbid) {
 	if (!isNumber(clbid)) {
 		throw new TypeError('addCourse(): clbid must be a number')
 	}
@@ -158,10 +171,18 @@ export function addCourseToSchedule(student, scheduleId, clbid) {
 
 	schedule.clbids = schedule.clbids.concat(clbid)
 
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }
 
-export function removeCourseFromSchedule(student, scheduleId, clbid) {
+module.exports.removeCourseFromSchedule = removeCourseFromSchedule
+function removeCourseFromSchedule(student, scheduleId, clbid) {
 	if (!isNumber(clbid)) {
 		throw new TypeError(`removeCourse(): clbid must be a number (was ${typeof clbid})`)
 	}
@@ -181,61 +202,78 @@ export function removeCourseFromSchedule(student, scheduleId, clbid) {
 
 	schedule.clbids = reject(schedule.clbids, id => id === clbid)
 
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }
 
-export function moveCourseToSchedule(student, { fromScheduleId, toScheduleId, clbid }) {
+module.exports.moveCourseToSchedule = moveCourseToSchedule
+function moveCourseToSchedule(student, { fromScheduleId, toScheduleId, clbid }) {
 	log(`moveCourseToSchedule(): moving ${clbid} from schedule ${fromScheduleId} to schedule ${toScheduleId}`)
 
 	student = removeCourseFromSchedule(student, fromScheduleId, clbid)
 	student = addCourseToSchedule(student, toScheduleId, clbid)
 
-	return { ...student }
+	return Object.assign({}, student)
 }
 
 
-export function addAreaToStudent(student, areaOfStudy) {
-	return { ...student, studies: [...student.studies, areaOfStudy] }
+module.exports.addAreaToStudent = addAreaToStudent
+function addAreaToStudent(student, areaOfStudy) {
+	return Object.assign({}, student, { studies: [...student.studies, areaOfStudy] })
 }
 
-export function removeAreaFromStudent(student, areaQuery) {
-	return { ...student, studies: reject(student.studies, areaQuery) }
+module.exports.removeAreaFromStudent = removeAreaFromStudent
+function removeAreaFromStudent(student, areaQuery) {
+	return Object.assign({}, student, { studies: reject(student.studies, areaQuery) })
 }
 
 
-export function setOverrideOnStudent(student, key, value) {
-	let overrides = { ...student.overrides }
+module.exports.setOverrideOnStudent = setOverrideOnStudent
+function setOverrideOnStudent(student, key, value) {
+	let overrides = Object.assign({}, student.overrides)
 	overrides[key] = value
-	return { ...student, overrides }
+	return Object.assign({}, student, { overrides })
 }
 
-export function removeOverrideFromStudent(student, key) {
+module.exports.removeOverrideFromStudent = removeOverrideFromStudent
+function removeOverrideFromStudent(student, key) {
 	let overrides = omit(student.overrides, key)
-	return { ...student, overrides }
+	return Object.assign({}, student, { overrides })
 }
 
 
-export function addFabricationToStudent(student, fabrication) {
+module.exports.addFabricationToStudent = addFabricationToStudent
+function addFabricationToStudent(student, fabrication) {
 	if (!('clbid' in fabrication)) {
 		throw new ReferenceError('addFabricationToStudent: fabrications must include a clbid')
 	}
 	if (typeof fabrication.clbid !== 'string') {
 		throw new TypeError('addFabricationToStudent: clbid must be a string')
 	}
-	let fabrications = { ...student.fabrications, [fabrication.clbid]: fabrication }
-	return { ...student, fabrications }
+	let fabrications = Object.assign({},
+		student.fabrications,
+		{ [fabrication.clbid]: fabrication })
+	return Object.assign({}, student, { fabrications })
 }
 
-export function removeFabricationFromStudent(student, fabricationId) {
+module.exports.removeFabricationFromStudent = removeFabricationFromStudent
+function removeFabricationFromStudent(student, fabricationId) {
 	if (typeof fabricationId !== 'string') {
 		throw new TypeError('removeCourseFromSchedule: clbid must be a string')
 	}
 	let fabrications = omit(student.fabrications, fabricationId)
-	return { ...student, fabrications }
+	return Object.assign({}, student, { fabrications })
 }
 
 
-export function moveScheduleInStudent(student, scheduleId, { year, semester }={}) {
+module.exports.moveScheduleInStudent = moveScheduleInStudent
+function moveScheduleInStudent(student, scheduleId, { year, semester }={}) {
 	if (year === undefined && semester === undefined) {
 		throw new RangeError('moveScheduleInStudent: Either year or semester must be provided.')
 	}
@@ -259,28 +297,52 @@ export function moveScheduleInStudent(student, scheduleId, { year, semester }={}
 		schedule.semester = semester
 	}
 
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }
 
-export function reorderScheduleInStudent(student, scheduleId, index) {
+module.exports.reorderScheduleInStudent = reorderScheduleInStudent
+function reorderScheduleInStudent(student, scheduleId, index) {
 	if (!(scheduleId in student.schedules)) {
 		throw new ReferenceError(`reorderScheduleInStudent: Could not find a schedule with an ID of "${scheduleId}".`)
 	}
 
-	let schedule = { ...student.schedules[scheduleId], index: index }
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	let schedule = Object.assign({}, student.schedules[scheduleId], { index: index })
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }
 
-export function renameScheduleInStudent(student, scheduleId, title) {
+module.exports.renameScheduleInStudent = renameScheduleInStudent
+function renameScheduleInStudent(student, scheduleId, title) {
 	if (!(scheduleId in student.schedules)) {
 		throw new ReferenceError(`renameScheduleInStudent: Could not find a schedule with an ID of "${scheduleId}".`)
 	}
 
-	let schedule = { ...student.schedules[scheduleId], title: title }
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	let schedule = Object.assign({}, student.schedules[scheduleId], { title: title })
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }
 
-export function reorderCourseInSchedule(student, scheduleId, { clbid, index }) {
+module.exports.reorderCourseInSchedule = reorderCourseInSchedule
+function reorderCourseInSchedule(student, scheduleId, { clbid, index }) {
 	if (!isNumber(clbid)) {
 		throw new TypeError('reorderCourse(): clbid must be a number')
 	}
@@ -308,5 +370,12 @@ export function reorderCourseInSchedule(student, scheduleId, { clbid, index }) {
 	schedule.clbids.splice(oldIndex, 1)
 	schedule.clbids.splice(index, 0, clbid)
 
-	return { ...student, schedules: { ...student.schedules, [schedule.id]: schedule } }
+	return Object.assign(
+		{},
+		student,
+		{
+			schedules: Object.assign({},
+				student.schedules,
+				{ [schedule.id]: schedule }),
+		})
 }

--- a/modules/object-student/validate-schedule.js
+++ b/modules/object-student/validate-schedule.js
@@ -1,13 +1,14 @@
-import { findWarnings } from './find-course-warnings'
-import filter from 'lodash/filter'
-import flatten from 'lodash/flatten'
-import identity from 'lodash/identity'
-import map from 'lodash/map'
-import some from 'lodash/some'
-import reject from 'lodash/reject'
-import isUndefined from 'lodash/isUndefined'
+'use strict'
+const { findWarnings } = require('./find-course-warnings')
+const filter = require('lodash/filter')
+const flatten = require('lodash/flatten')
+const identity = require('lodash/identity')
+const map = require('lodash/map')
+const some = require('lodash/some')
+const reject = require('lodash/reject')
+const isUndefined = require('lodash/isUndefined')
 
-export function validateSchedule(schedule) {
+function validateSchedule(schedule) {
 	// Checks to see if the schedule is valid
 	let courses = schedule.courses
 
@@ -22,5 +23,7 @@ export function validateSchedule(schedule) {
 	const warnings = map(filtered, c => c.warning)
 	const hasConflict = some(warnings, w => w === true)
 
-	return { ...schedule, hasConflict, conflicts }
+	return Object.assign({}, schedule, { hasConflict, conflicts })
 }
+
+module.exports.validateSchedule = validateSchedule

--- a/modules/object-student/validate-schedules.js
+++ b/modules/object-student/validate-schedules.js
@@ -1,10 +1,14 @@
-import mapValues from 'lodash/mapValues'
-import { validateSchedule } from './validate-schedule'
+'use strict'
 
-export function validateSchedules(student) {
+const mapValues = require('lodash/mapValues')
+const { validateSchedule } = require('./validate-schedule')
+
+function validateSchedules(student) {
 	return new Promise(resolve => {
 		let { schedules } = student
 		schedules = mapValues(schedules, validateSchedule)
-		resolve({ ...student, schedules })
+		resolve(Object.assign({}, student, { schedules }))
 	})
 }
+
+module.exports.validateSchedules = validateSchedules

--- a/modules/school-st-olaf-college/course-info/expand-year.js
+++ b/modules/school-st-olaf-college/course-info/expand-year.js
@@ -1,5 +1,8 @@
 // @flow
-export function expandYear(year: string | number, short?: boolean=false, separator?: string='—') {
+'use strict'
+
+module.exports.expandYear = expandYear
+function expandYear(year: string | number, short?: boolean=false, separator?: string='—') {
 	if (typeof year === 'string') {
 		year = parseInt(year, 10)
 	}
@@ -11,7 +14,8 @@ export function expandYear(year: string | number, short?: boolean=false, separat
 }
 
 // 2012 => 2012-2013
-export function expandYearToFull(year: ?number, separator?: string='—') {
+module.exports.expandYearToFull = expandYearToFull
+function expandYearToFull(year: ?number, separator?: string='—') {
 	if (year === undefined || year === null) {
 		return '???'
 	}
@@ -20,7 +24,8 @@ export function expandYearToFull(year: ?number, separator?: string='—') {
 }
 
 // 2012 => 2012-13
-export function expandYearToShort(year: ?number, separator?: string='—') {
+module.exports.expandYearToShort = expandYearToShort
+function expandYearToShort(year: ?number, separator?: string='—') {
 	if (year === undefined || year === null) {
 		return '???'
 	}

--- a/modules/school-st-olaf-college/course-info/index.js
+++ b/modules/school-st-olaf-college/course-info/index.js
@@ -1,4 +1,5 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export { expandYear } from './expand-year'
-export { semesterName } from './semester-name'
-export { toPrettyTerm } from './to-pretty-term'
+'use strict'
+
+module.exports.expandYear = require('./expand-year').expandYear
+module.exports.semesterName = require('./semester-name').semesterName
+module.exports.toPrettyTerm = require('./to-pretty-term').toPrettyTerm

--- a/modules/school-st-olaf-college/course-info/semester-name.js
+++ b/modules/school-st-olaf-college/course-info/semester-name.js
@@ -1,5 +1,7 @@
 // @flow
-import has from 'lodash/has'
+'use strict'
+
+const has = require('lodash/has')
 
 const SEMESTERS = {
 	'0': 'Abroad',
@@ -12,7 +14,7 @@ const SEMESTERS = {
 }
 
 // Takes a semester number and returns the associated semester string.
-export function semesterName(semester: string | number): string {
+function semesterName(semester: string | number): string {
 	if (typeof semester === 'number') {
 		semester = String(semester)
 	}
@@ -20,3 +22,5 @@ export function semesterName(semester: string | number): string {
     ? SEMESTERS[semester]
     : `Unknown (${semester})`
 }
+
+module.exports.semesterName = semesterName

--- a/modules/school-st-olaf-college/course-info/to-pretty-term.js
+++ b/modules/school-st-olaf-college/course-info/to-pretty-term.js
@@ -1,14 +1,18 @@
 // @flow
-import { semesterName } from './semester-name'
-import { expandYear } from './expand-year'
+'use strict'
+
+const { semesterName } = require('./semester-name')
+const { expandYear } = require('./expand-year')
 
 /* Takes a term and makes it pretty.
  * eg. {in: 20121, out: Fall 2012-13}
  */
-export function toPrettyTerm(term: number): string {
+function toPrettyTerm(term: number): string {
 	const strterm = String(term)
 	const year = strterm.substr(0, 4)
 	const sem = strterm.substr(4, 1)
 
 	return `${semesterName(sem)} ${expandYear(year)}`
 }
+
+module.exports.toPrettyTerm = toPrettyTerm

--- a/modules/school-st-olaf-college/deptnums/build-dept-num.js
+++ b/modules/school-st-olaf-college/deptnums/build-dept-num.js
@@ -1,5 +1,7 @@
 // @flow
-import { buildDeptString } from './build-dept'
+'use strict'
+
+const { buildDeptString } = require('./build-dept')
 
 /**
  * Builds a deptnum string from a course.
@@ -8,7 +10,7 @@ import { buildDeptString } from './build-dept'
  * @param {Boolean} includeSection - whether or not to include the section in the result
  * @returns {String} - the deptnum string
  */
-export function buildDeptNum({ departments, number, section='', deptnum }: {departments: string[], number: number, section?: string, deptnum?: string}, includeSection?: boolean=false) {
+function buildDeptNum({ departments, number, section='', deptnum }: {departments: string[], number: number, section?: string, deptnum?: string}, includeSection?: boolean=false) {
 	const dept = buildDeptString(departments)
 	const deptnumString = deptnum || `${dept} ${number}`
 
@@ -18,3 +20,5 @@ export function buildDeptNum({ departments, number, section='', deptnum }: {depa
 
 	return deptnumString
 }
+
+module.exports.buildDeptNum = buildDeptNum

--- a/modules/school-st-olaf-college/deptnums/build-dept.js
+++ b/modules/school-st-olaf-college/deptnums/build-dept.js
@@ -1,5 +1,7 @@
 // @flow
-import { normalizeDepartment } from '../../hanson-format/convert-department'
+'use strict'
+
+const { normalizeDepartment } = require('../../hanson-format/convert-department')
 
 /**
  * Builds a department string from a course.
@@ -11,10 +13,12 @@ import { normalizeDepartment } from '../../hanson-format/convert-department'
  * @param {String[]} departments - the course departments
  * @returns {String} - the department string
  */
-export function buildDeptString(departments: string[]) {
+function buildDeptString(departments: string[]) {
 	if (!departments || !departments.length) {
 		return 'NONE'
 	}
 
 	return departments.map(normalizeDepartment).join('/')
 }
+
+module.exports.buildDeptString = buildDeptString

--- a/modules/school-st-olaf-college/deptnums/dept-num-regex.js
+++ b/modules/school-st-olaf-college/deptnums/dept-num-regex.js
@@ -1,2 +1,6 @@
 // @flow
-export const deptNumRegex = /(([A-Z]+)(?=\/)(?:\/)([A-Z]+)|[A-Z]+) *([0-9]{3,}) *([A-Z]?)/i
+'use strict'
+
+const deptNumRegex = /(([A-Z]+)(?=\/)(?:\/)([A-Z]+)|[A-Z]+) *([0-9]{3,}) *([A-Z]?)/i
+
+module.exports.deptNumRegex = deptNumRegex

--- a/modules/school-st-olaf-college/deptnums/index.js
+++ b/modules/school-st-olaf-college/deptnums/index.js
@@ -1,6 +1,7 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export { buildDeptString } from './build-dept'
-export { buildDeptNum } from './build-dept-num'
-export { deptNumRegex } from './dept-num-regex'
-export { quacksLikeDeptNum } from './quacks-like-dept-num'
-export { splitDeptNum } from './split-dept-num'
+'use strict'
+
+module.exports.buildDeptString = require('./build-dept').buildDeptString
+module.exports.buildDeptNum = require('./build-dept-num').buildDeptNum
+module.exports.deptNumRegex = require('./dept-num-regex').deptNumRegex
+module.exports.quacksLikeDeptNum = require('./quacks-like-dept-num').quacksLikeDeptNum
+module.exports.splitDeptNum = require('./split-dept-num').splitDeptNum

--- a/modules/school-st-olaf-college/deptnums/quacks-like-dept-num.js
+++ b/modules/school-st-olaf-college/deptnums/quacks-like-dept-num.js
@@ -1,7 +1,11 @@
 // @flow
-import { deptNumRegex } from './dept-num-regex'
+'use strict'
+
+const { deptNumRegex } = require('./dept-num-regex')
 
 // Checks if a string looks like a deptnum.
-export function quacksLikeDeptNum(deptNumString: string) {
+function quacksLikeDeptNum(deptNumString: string) {
 	return deptNumRegex.test(deptNumString)
 }
+
+module.exports.quacksLikeDeptNum = quacksLikeDeptNum

--- a/modules/school-st-olaf-college/deptnums/split-dept-num.js
+++ b/modules/school-st-olaf-college/deptnums/split-dept-num.js
@@ -1,5 +1,7 @@
 // @flow
-import { deptNumRegex } from './dept-num-regex'
+'use strict'
+
+const { deptNumRegex } = require('./dept-num-regex')
 
 /**
  * Splits a deptnum string (like "AS/RE 230A") into its components,
@@ -9,7 +11,7 @@ import { deptNumRegex } from './dept-num-regex'
  * @param {Boolean} includeSection - include the section in the result?
  * @returns {Object} - the result
  */
-export function splitDeptNum(deptNumString: string, includeSection?: boolean=false) {
+function splitDeptNum(deptNumString: string, includeSection?: boolean=false) {
 	// "AS/RE 230A" -> ["AS/RE 230A", "AS/RE", "AS", "RE", "230", "A"]
 	// -> {departments: ['AS', 'RE'], number: 230}
 	let matches = deptNumRegex.exec(deptNumString)
@@ -29,3 +31,5 @@ export function splitDeptNum(deptNumString: string, includeSection?: boolean=fal
 
 	return deptNum
 }
+
+module.exports.splitDeptNum = splitDeptNum

--- a/modules/school-st-olaf-college/index.js
+++ b/modules/school-st-olaf-college/index.js
@@ -1,22 +1,41 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export {
+'use strict'
+
+const {
 	expandYear,
 	semesterName,
 	toPrettyTerm,
-} from './course-info'
+} = require('./course-info')
 
-export {
+const {
 	buildDeptString,
 	buildDeptNum,
 	deptNumRegex,
 	quacksLikeDeptNum,
 	splitDeptNum,
-} from './deptnums'
+} = require('./deptnums')
 
-export {
+const {
 	convertStudent,
 	getStudentInfo,
 	checkIfLoggedIn,
 	ExtensionNotLoadedError,
 	ExtensionTooOldError,
-} from './sis-parser'
+} = require('./sis-parser')
+
+module.exports = {
+	expandYear,
+	semesterName,
+	toPrettyTerm,
+
+	buildDeptString,
+	buildDeptNum,
+	deptNumRegex,
+	quacksLikeDeptNum,
+	splitDeptNum,
+
+	convertStudent,
+	getStudentInfo,
+	checkIfLoggedIn,
+	ExtensionNotLoadedError,
+	ExtensionTooOldError,
+}

--- a/modules/school-st-olaf-college/sis-parser/convert-imported-student.js
+++ b/modules/school-st-olaf-college/sis-parser/convert-imported-student.js
@@ -1,29 +1,30 @@
-import { Student, Schedule } from '../../object-student'
-import groupBy from 'lodash/groupBy'
-import map from 'lodash/map'
-import forEach from 'lodash/forEach'
-import uniq from 'lodash/uniq'
-import fromPairs from 'lodash/fromPairs'
-import filter from 'lodash/filter'
-import uuid from 'uuid/v4'
+'use strict'
+const { Student, Schedule } = require('../../object-student')
+const groupBy = require('lodash/groupBy')
+const map = require('lodash/map')
+const forEach = require('lodash/forEach')
+const uniq = require('lodash/uniq')
+const fromPairs = require('lodash/fromPairs')
+const filter = require('lodash/filter')
+const uuid = require('uuid/v4')
 
-export function convertStudent({ courses, degrees }, getCourse) {
+module.exports.convertStudent = convertStudent
+function convertStudent({ courses, degrees }, getCourse) {
 	return Promise.all([
 		processSchedules(courses, getCourse),
 		processDegrees(degrees),
 	]).then(([schedulesAndFabrications, info]) => {
 		let { schedules, fabrications } = schedulesAndFabrications
 
-		return Student({
-			...info,
+		return Student(Object.assign({}, info, {
 			schedules,
 			fabrications,
-		})
+		}))
 	})
 }
 
-
-export function processSchedules(courses, getCourse) {
+module.exports.processSchedules = processSchedules
+function processSchedules(courses, getCourse) {
 	return Promise.all(map(courses, course => {
 		return getCourse(course).then(resolvedCourse => {
 			if (resolvedCourse.error) {
@@ -54,7 +55,8 @@ export function processSchedules(courses, getCourse) {
 }
 
 
-export function processDegrees(degrees) {
+module.exports.processDegrees = processDegrees
+function processDegrees(degrees) {
 	let singularData = resolveSingularDataPoints(degrees)
 	let studies = []
 
@@ -65,14 +67,12 @@ export function processDegrees(degrees) {
 		studies = studies.concat(emphases.map(name =>       ({ name, type: 'emphasis', revision: 'latest' })))
 	}
 
-	return {
-		...singularData,
-		studies,
-	}
+	return Object.assign({}, singularData, { studies })
 }
 
 
-export function resolveSingularDataPoints(degrees) {
+module.exports.resolveSingularDataPoints = resolveSingularDataPoints
+function resolveSingularDataPoints(degrees) {
 	let thereShouldOnlyBeOne = {
 		names: map(degrees, d => d.name),
 		advisors: map(degrees, d => d.advisor),

--- a/modules/school-st-olaf-college/sis-parser/import-student/courses.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/courses.js
@@ -1,12 +1,13 @@
-import map from 'lodash/map'
-import {
+'use strict'
+const map = require('lodash/map')
+const {
 	fetchHtml,
 	getText,
 	removeInternalWhitespace,
 	getTextItems,
-} from './lib'
-import { selectAll, selectOne } from 'css-select'
-import { COURSES_URL } from './urls'
+} = require('./lib')
+const { selectAll, selectOne } = require('css-select')
+const { COURSES_URL } = require('./urls')
 
 function convertRowToCourse(term, sisRow) {
 	// the columns go: deptnum, lab, name, halfsemester, credits, passfail, gereqs, times, locations, instructors
@@ -31,7 +32,8 @@ function convertRowToCourse(term, sisRow) {
 }
 
 
-export function getCoursesFromHtml(dom, term) {
+module.exports.getCoursesFromHtml = getCoursesFromHtml
+function getCoursesFromHtml(dom, term) {
 	let courseRows = selectAll('.sis-line1, .sis-line2', dom)
 
 	if (!courseRows.length) {
@@ -52,6 +54,7 @@ function getCourses(studentId, term) {
 }
 
 
-export function collectAllCourses(studentId, terms) {
+module.exports.collectAllCourses = collectAllCourses
+function collectAllCourses(studentId, terms) {
 	return Promise.all(map(terms, term => getCourses(studentId, term)))
 }

--- a/modules/school-st-olaf-college/sis-parser/import-student/degree-audit.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/degree-audit.js
@@ -1,11 +1,13 @@
-import map from 'lodash/map'
-import fromPairs from 'lodash/fromPairs'
-import mapKeys from 'lodash/mapKeys'
-import unzip from 'lodash/unzip'
-import filter from 'lodash/filter'
-import { selectAll, selectOne } from 'css-select'
-import { partitionByIndex } from '../../../lib'
-import { getText } from './lib'
+'use strict'
+
+const map = require('lodash/map')
+const fromPairs = require('lodash/fromPairs')
+const mapKeys = require('lodash/mapKeys')
+const unzip = require('lodash/unzip')
+const filter = require('lodash/filter')
+const { selectAll, selectOne } = require('css-select')
+const { partitionByIndex } = require('../../../lib')
+const { getText } = require('./lib')
 
 function extractInformationFromInfoTable(table) {
 	// So "info" is the first table; it's essentially key-value pairs, in column-row fashion.
@@ -54,7 +56,8 @@ function extractInformationFromAreaTable(table) {
 	}
 }
 
-export function extractInformationFromDegreeAudit(auditInfo, infoElement) {
+module.exports.extractInformationFromDegreeAudit = extractInformationFromDegreeAudit
+function extractInformationFromDegreeAudit(auditInfo, infoElement) {
 	let [degreeType] = getText(selectOne('h3', auditInfo)).match(/B\.[AM]\./)
 	if (degreeType === 'B.A.') {
 		degreeType = 'Bachelor of Arts'
@@ -70,9 +73,5 @@ export function extractInformationFromDegreeAudit(auditInfo, infoElement) {
 	let info = extractInformationFromInfoTable(infoTable)
 	let areas = extractInformationFromAreaTable(areaTable)
 
-	return {
-		...info,
-		...areas,
-		degree: degreeType,
-	}
+	return Object.assign({}, info, areas, { degree: degreeType })
 }

--- a/modules/school-st-olaf-college/sis-parser/import-student/get-student-info.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/get-student-info.js
@@ -1,11 +1,12 @@
-import props from 'p-props'
-import flatten from 'lodash/flatten'
-import { AuthError, NetworkError } from '../../../lib'
-import { fetchHtml } from './lib'
-import { extractTermList } from './term-list'
-import { collectAllCourses } from './courses'
-import { getGraduationInformation } from './graduation-info'
-import { COURSES_URL, DEGREE_AUDIT_URL } from './urls'
+'use strict'
+const props = require('p-props')
+const flatten = require('lodash/flatten')
+const { AuthError, NetworkError } = require('../../../lib')
+const { fetchHtml } = require('./lib')
+const { extractTermList } = require('./term-list')
+const { collectAllCourses } = require('./courses')
+const { getGraduationInformation } = require('./graduation-info')
+const { COURSES_URL, DEGREE_AUDIT_URL } = require('./urls')
 
 
 function loadPages(studentId) {
@@ -35,7 +36,8 @@ function flattenData({ coursesByTerm, studentInfo }) {
 }
 
 
-export function getStudentInfo(studentId) {
+module.exports.getStudentInfo = getStudentInfo
+function getStudentInfo(studentId) {
 	if (!navigator.onLine) {
 		return Promise.reject(new NetworkError('The network is offline.'))
 	}

--- a/modules/school-st-olaf-college/sis-parser/import-student/graduation-info.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/graduation-info.js
@@ -1,8 +1,10 @@
-import includes from 'lodash/includes'
-import { extractInformationFromDegreeAudit } from './degree-audit'
-import { selectAll } from 'css-select'
+'use strict'
+const includes = require('lodash/includes')
+const { extractInformationFromDegreeAudit } = require('./degree-audit')
+const { selectAll } = require('css-select')
 
-export function getGraduationInformation(dom) {
+module.exports.getGraduationInformation = getGraduationInformation
+function getGraduationInformation(dom) {
 	// #bigbodymainstyle
 	//   table  (top navigation)
 	//   form

--- a/modules/school-st-olaf-college/sis-parser/import-student/index.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/index.js
@@ -1,6 +1,15 @@
-export { getStudentInfo } from './get-student-info'
-export { checkIfLoggedIn } from './logged-in'
-export {
+'use strict'
+
+const { getStudentInfo } = require('./get-student-info')
+const { checkIfLoggedIn } = require('./logged-in')
+const {
 	ExtensionNotLoadedError,
 	ExtensionTooOldError,
-} from './lib'
+} = require('./lib')
+
+module.exports = {
+	getStudentInfo,
+	checkIfLoggedIn,
+	ExtensionNotLoadedError,
+	ExtensionTooOldError,
+}

--- a/modules/school-st-olaf-college/sis-parser/import-student/lib.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/lib.js
@@ -1,12 +1,16 @@
-import { parseHtml } from '../parse-html'
-import forOwn from 'lodash/forOwn'
-import forEach from 'lodash/forEach'
-import uuid from 'uuid/v4'
+'use strict'
+const { parseHtml } = require('../parse-html')
+const forOwn = require('lodash/forOwn')
+const forEach = require('lodash/forEach')
+const uuid = require('uuid/v4')
 
-export class ExtensionNotLoadedError extends Error {}
-export class ExtensionTooOldError extends Error {}
+class ExtensionNotLoadedError extends Error {}
+class ExtensionTooOldError extends Error {}
+module.exports.ExtensionNotLoadedError = ExtensionNotLoadedError
+module.exports.ExtensionTooOldError = ExtensionTooOldError
 
-export function fetchHtml(url, fetchArgs, fetchBody) {
+module.exports.fetchHtml = fetchHtml
+function fetchHtml(url, fetchArgs, fetchBody) {
 	if (!global.gobbldygook_extension) {
 		return Promise.reject(new ExtensionNotLoadedError('Extension not loaded'))
 	}
@@ -49,7 +53,8 @@ export function fetchHtml(url, fetchArgs, fetchBody) {
 	})
 }
 
-export function buildFormData(obj) {
+module.exports.buildFormData = buildFormData
+function buildFormData(obj) {
 	let formData = new FormData()
 	forOwn(obj, (val, key) => {
 		formData.append(key, val)
@@ -57,11 +62,13 @@ export function buildFormData(obj) {
 	return formData
 }
 
-export function getText(elems) {
+module.exports.getText = getText
+function getText(elems) {
 	return getTextItems(elems).join('')
 }
 
-export function getTextItems(elems) {
+module.exports.getTextItems = getTextItems
+function getTextItems(elems) {
 	if (elems.children) {
 		elems = elems.children
 	}
@@ -83,6 +90,7 @@ export function getTextItems(elems) {
 	return ret.filter(s => s.length)
 }
 
-export function removeInternalWhitespace(text) {
+module.exports.removeInternalWhitespace = removeInternalWhitespace
+function removeInternalWhitespace(text) {
 	return text.split(/\s+/).join(' ')
 }

--- a/modules/school-st-olaf-college/sis-parser/import-student/logged-in.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/logged-in.js
@@ -1,10 +1,12 @@
-import { AuthError } from '../../../lib'
-import { extractStudentIds } from './student-ids'
-import { COURSES_URL } from './urls'
-import { fetchHtml, getText } from './lib'
-import { selectOne } from 'css-select'
+'use strict'
+const { AuthError } = require('../../../lib')
+const { extractStudentIds } = require('./student-ids')
+const { COURSES_URL } = require('./urls')
+const { fetchHtml, getText } = require('./lib')
+const { selectOne } = require('css-select')
 
-export function checkPageIsLoggedIn(response) {
+module.exports.checkPageIsLoggedIn = checkPageIsLoggedIn
+function checkPageIsLoggedIn(response) {
 	let errorMsg = selectOne('[style="text-align:center"]', response)
 	let badMsg = 'Please use your St. Olaf Google account when accessing SIS.'
 	if (errorMsg && getText(errorMsg) === badMsg) {
@@ -16,6 +18,7 @@ export function checkPageIsLoggedIn(response) {
 	return extractStudentIds(response)
 }
 
-export function checkIfLoggedIn() {
+module.exports.checkIfLoggedIn = checkIfLoggedIn
+function checkIfLoggedIn() {
 	return fetchHtml(COURSES_URL).then(checkPageIsLoggedIn)
 }

--- a/modules/school-st-olaf-college/sis-parser/import-student/student-ids.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/student-ids.js
@@ -1,9 +1,11 @@
-import { selectAll } from 'css-select'
-import map from 'lodash/map'
-import filter from 'lodash/filter'
-import uniq from 'lodash/uniq'
+'use strict'
+const { selectAll } = require('css-select')
+const map = require('lodash/map')
+const filter = require('lodash/filter')
+const uniq = require('lodash/uniq')
 
-export function extractStudentIds(dom) {
+module.exports.extractStudentIds = extractStudentIds
+function extractStudentIds(dom) {
 	let idElements = selectAll('[name=stnum]', dom)
 	return uniq(map(filter(idElements, el => el), el => Number(el.attribs.value)))
 }

--- a/modules/school-st-olaf-college/sis-parser/import-student/term-list.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/term-list.js
@@ -1,6 +1,8 @@
-import { selectOne, selectAll } from 'css-select'
+'use strict'
+const { selectOne, selectAll } = require('css-select')
 
-export function extractTermList(dom) {
+module.exports.extractTermList = extractTermList
+function extractTermList(dom) {
 	const termSelector = selectOne('[name=searchyearterm]', dom)
 	if (termSelector === null) {
 		return []

--- a/modules/school-st-olaf-college/sis-parser/import-student/urls.js
+++ b/modules/school-st-olaf-college/sis-parser/import-student/urls.js
@@ -1,2 +1,3 @@
-export const COURSES_URL = 'https://www.stolaf.edu/sis/st-courses.cfm'
-export const DEGREE_AUDIT_URL = 'https://www.stolaf.edu/sis/st-degreeaudit.cfm'
+'use strict'
+module.exports.COURSES_URL = 'https://www.stolaf.edu/sis/st-courses.cfm'
+module.exports.DEGREE_AUDIT_URL = 'https://www.stolaf.edu/sis/st-degreeaudit.cfm'

--- a/modules/school-st-olaf-college/sis-parser/index.js
+++ b/modules/school-st-olaf-college/sis-parser/index.js
@@ -1,9 +1,19 @@
-// can't use export * with babel: see https://github.com/babel/babel/issues/4446
-export { convertStudent } from './convert-imported-student'
+'use strict'
 
-export {
+const { convertStudent } = require('./convert-imported-student')
+
+const {
 	getStudentInfo,
 	checkIfLoggedIn,
 	ExtensionNotLoadedError,
 	ExtensionTooOldError,
-} from './import-student'
+} = require('./import-student')
+
+module.exports = {
+	convertStudent,
+
+	getStudentInfo,
+	checkIfLoggedIn,
+	ExtensionNotLoadedError,
+	ExtensionTooOldError,
+}

--- a/modules/school-st-olaf-college/sis-parser/parse-html.js
+++ b/modules/school-st-olaf-college/sis-parser/parse-html.js
@@ -1,6 +1,8 @@
-import htmlparser from 'htmlparser2'
+// @flow
+'use strict'
+const htmlparser = require('htmlparser2')
 
-export function parseHtml(string) {
+function parseHtml(string: string) {
 	return htmlparser.parseDOM(string, {
 		withDomLvl1: true,
 		normalizeWhitespace: false,
@@ -8,3 +10,5 @@ export function parseHtml(string) {
 		decodeEntities: true,
 	})
 }
+
+module.exports.parseHtml = parseHtml


### PR DESCRIPTION
- It's not yet standardized
- It won't land in `node` until late 2018, at the _earliest_

So, as I like to run the \*cli functions in the terminal, this allows us to run them without having to use babel-node, which shaves like 1.5s off the launch time.

This also adds a devdep on [`flow-remove-types`](https://github.com/flowtype/flow-remove-types), which is much faster than babel w/the flow plugin.