### PR TITLE
StudentSummary rework

### DIFF
--- a/modules/web/components/content-editable.js
+++ b/modules/web/components/content-editable.js
@@ -8,6 +8,7 @@ const log = debug('web:react')
 class ContentEditable extends Component {
     props: {
         className?: string,
+        editable?: boolean,
         multiLine?: boolean,
         onBlur?: (string) => any,
         onChange: (string) => any,
@@ -18,6 +19,7 @@ class ContentEditable extends Component {
     };
 
     static defaultProps = {
+        editable: true,
         onChange: () => {},
         multiLine: false,
         value: '',
@@ -74,7 +76,7 @@ class ContentEditable extends Component {
                 onBlur={this.handleChange}
                 onKeyDown={this.handleKeyDown}
                 onFocus={this.handleFocus}
-                contentEditable={true}
+                contentEditable={this.props.editable}
                 dangerouslySetInnerHTML={{ __html: this.props.value }}
             />
         )


### PR DESCRIPTION
This PR reworks the hideous mess that is &lt;StudentSummary/> into a somewhat more manageable mess, by the power of ~~Grayskull~~ React components.

I split it into a bunch of littler components, with most of that string manipulation stuff relegated to a new `<DegreeSummary/>` component.

Compare: [old][old] to [new][new].

[old]: https://github.com/hawkrives/gobbldygook/blob/b9693058c73839feeae07f385dc7eb6668d87498/modules/web/modules/student/student-summary.js
[new]: https://github.com/hawkrives/gobbldygook/blob/33dab7c7ab5564f6fa69d7c2bc1562a6be7aea7f/modules/web/modules/student/student-summary.js