### PR TITLE
Add a Safari-based toggle for disabling database access

### DIFF
--- a/modules/examine-student/pluralize-area.js
+++ b/modules/examine-student/pluralize-area.js
@@ -1,12 +1,12 @@
 // @flow
-import type { AreaOfStudyTypeEnum } from './types'
+
 /**
  * Pluralizes an area type
  * @private
  * @param {string} type - the type to pluralize
  * @returns {string} - the pluralized type
  */
-export default function pluralizeArea(type: AreaOfStudyTypeEnum) {
+export default function pluralizeArea(type: string) {
     switch (type.toLowerCase()) {
         case 'degree':
             return 'degrees'

--- a/modules/web/helpers/get-courses.js
+++ b/modules/web/helpers/get-courses.js
@@ -51,8 +51,10 @@ export function getCourse({ clbid, term }: {clbid: number, term: number}, fabric
         return fabrications[clbid]
     }
 
-    const getCourseFrom = getCourseFromDatabase
-    // const getCourseFrom = getCourseFromNetwork
+    let getCourseFrom = getCourseFromDatabase
+    if (global.useNetworkOnly) {
+        getCourseFrom = getCourseFromNetwork
+    }
 
     return getCourseFrom(clbid)
         .then(course => course || { clbid, term, error: `Could not find ${clbid}` })

--- a/modules/web/helpers/get-courses.js
+++ b/modules/web/helpers/get-courses.js
@@ -17,9 +17,7 @@ export function getCourseFromNetwork(clbid: number) {
 
     const path = `${baseUrl}/courses/${dir}/${id}.json`
 
-    const promise = fetch(path).then(status).then(json)
-
-    networkCache[clbid] = promise
+    networkCache[clbid] = fetch(path).then(status).then(json)
 
     return networkCache[clbid]
 }
@@ -30,13 +28,11 @@ export function getCourseFromDatabase(clbid: number) {
         return courseCache[clbid]
     }
 
-    const promise = db
+    courseCache[clbid] = db
         .store('courses')
         .index('clbid')
         .get(clbid)
         .then(course => omit(course, ['profWords', 'words', 'sourcePath']))
-
-    courseCache[clbid] = promise
 
     return courseCache[clbid].then(course => {
         delete courseCache[clbid]

--- a/modules/web/helpers/get-courses.js
+++ b/modules/web/helpers/get-courses.js
@@ -1,33 +1,40 @@
+// @flow
 import db from './db'
 import map from 'lodash/map'
 import omit from 'lodash/omit'
+import padStart from 'lodash/padStart'
+import {status, json} from '../../lib/fetch-helpers'
 
-const courseCache = Object.create(null)
-// Gets a course from the database.
-// @param {Number} clbid - a class/lab ID
-// @param {Number} term - a course term
-// @param {Object} fabrications - a (clbid, course) object of fabrications
-// @returns {Promise} - TreoDatabasePromise
-// @fulfill {Object} - the course object, potentially with an embedded error message.
-export function getCourse({ clbid, term }, fabrications = {}) {
-    if (clbid in fabrications) {
-        return fabrications[clbid]
+const baseUrl = 'https://stodevx.github.io/course-data'
+const networkCache = Object.create(null)
+export function getCourseFromNetwork(clbid: number) {
+    if (clbid in networkCache) {
+        return networkCache[clbid]
     }
 
+    const id = padStart(clbid.toString(), 10, '0')
+    const dir = (Math.floor(clbid / 1000) * 1000).toString()
+
+    const path = `${baseUrl}/courses/${dir}/${id}.json`
+
+    const promise = fetch(path).then(status).then(json)
+
+    networkCache[clbid] = promise
+
+    return networkCache[clbid]
+}
+
+const courseCache = Object.create(null)
+export function getCourseFromDatabase(clbid: number) {
     if (clbid in courseCache) {
         return courseCache[clbid]
     }
 
-    let promise = db
+    const promise = db
         .store('courses')
         .index('clbid')
         .get(clbid)
-        .then(
-            course =>
-                course || { clbid, term, error: `Could not find ${clbid}` }
-        )
         .then(course => omit(course, ['profWords', 'words', 'sourcePath']))
-        .catch(error => ({ clbid, term, error: error.message }))
 
     courseCache[clbid] = promise
 
@@ -36,13 +43,25 @@ export function getCourse({ clbid, term }, fabrications = {}) {
         return course
     })
 }
-// export function getCourse({clbid, term}) {
-// 	return db.store('courses')
-// 		.index('clbid')
-// 		.get(clbid)
-// 		.then(course => course || {clbid, term, error: `Could not find ${clbid}`})
-// 		.catch(error => ({clbid, term, error: error.message}))
-// }
+
+// Gets a course from the database.
+// @param {Number} clbid - a class/lab ID
+// @param {Number} term - a course term
+// @param {Object} fabrications - a (clbid, course) object of fabrications
+// @returns {Promise} - TreoDatabasePromise
+// @fulfill {Object} - the course object, potentially with an embedded error message.
+export function getCourse({ clbid, term }: {clbid: number, term: number}, fabrications: any = {}) {
+    if (clbid in fabrications) {
+        return fabrications[clbid]
+    }
+
+    const getCourseFrom = getCourseFromDatabase
+    // const getCourseFrom = getCourseFromNetwork
+
+    return getCourseFrom(clbid)
+        .then(course => course || { clbid, term, error: `Could not find ${clbid}` })
+        .catch(error => ({ clbid, term, error: error.message }))
+}
 
 /**
  * Takes a list of clbids, and returns a list of the course objects for those
@@ -53,6 +72,6 @@ export function getCourse({ clbid, term }, fabrications = {}) {
  * @returns {Promise} - a promise for the course data
  * @fulfill {Object[]} - the courses.
  */
-export function getCourses(clbids, fabrications) {
+export function getCourses(clbids: number[], fabrications: any) {
     return Promise.all(map(clbids, c => getCourse(c, fabrications)))
 }

--- a/modules/web/helpers/load-area.js
+++ b/modules/web/helpers/load-area.js
@@ -1,9 +1,14 @@
+// @flow
 import db from './db'
 import { enhanceHanson } from '../../hanson-format'
 import some from 'lodash/some'
 import maxBy from 'lodash/maxBy'
+import find from 'lodash/find'
+import kebabCase from 'lodash/kebabCase'
 import yaml from 'js-yaml'
 import debug from 'debug'
+import pluralizeArea from '../../examine-student/pluralize-area'
+import {status, text} from '../../lib/fetch-helpers'
 const log = debug('worker:load-area')
 
 function resolveArea(areas, query) {
@@ -16,18 +21,41 @@ function resolveArea(areas, query) {
     }
 }
 
-function loadArea(areaQuery) {
-    const { name, type, revision, source, isCustom } = areaQuery
+function transform(areaSource) {
+    return enhanceHanson(yaml.safeLoad(areaSource))
+}
 
-    let area = { ...areaQuery }
-    if (isCustom && source) {
-        return Promise.resolve({
-            ...areaQuery,
-            _area: enhanceHanson(yaml.safeLoad(source)),
-        })
+type AreaQueryType = {
+    name: string,
+    type: string,
+    revision: string,
+    source: string,
+    isCustom: string,
+};
+
+const baseUrl = 'https://hawkrives.github.io/gobbldygook-area-data'
+const networkCache = Object.create(null)
+function loadAreaFromNetwork({name, type, revision}: AreaQueryType) {
+    const id = `{${name}, ${type}, ${revision}}`
+    if (id in networkCache) {
+        return networkCache[id]
     }
 
-    let dbQuery = { name: [name], type: [type] }
+    const path = `${baseUrl}/${pluralizeArea(type)}/${kebabCase(name)}.yaml`
+
+    networkCache[id] = fetch(path).then(status).then(text).then(transform)
+
+    return networkCache[id].then(area => {
+        return {
+            name, type, revision, _area: area,
+        }
+    })
+}
+
+function loadAreaFromDatabase(areaQuery: AreaQueryType) {
+    const { name, type, revision } = areaQuery
+
+    let dbQuery: any = { name: [name], type: [type] }
     if (revision && revision !== 'latest') {
         dbQuery.revision = [revision]
     }
@@ -36,7 +64,7 @@ function loadArea(areaQuery) {
         .store('areas')
         .query(dbQuery)
         .then(result => {
-            if (result === undefined) {
+            if (!result || !result.length) {
                 return {
                     ...areaQuery,
                     _error: `the area "${name}" (${type}) could not be found with the query ${JSON.stringify(dbQuery)}`,
@@ -45,32 +73,28 @@ function loadArea(areaQuery) {
 
             if (result.length === 1) {
                 result = result[0]
-            } else if (result.length >= 2) {
-                result = resolveArea(result, dbQuery)
             } else {
-                return {
-                    name,
-                    type,
-                    revision,
-                    _error: `the area "${name}" (${type}) could not be found with the query ${JSON.stringify(dbQuery)}`,
-                }
+                result = resolveArea(result, dbQuery)
             }
 
             return { ...areaQuery, _area: enhanceHanson(result) }
         })
         .catch(err => {
             log(err) // we can probably remove this in the future
-            area._error = `Could not find area ${JSON.stringify(dbQuery)} (error: ${err.message})`
-            return area
+            return {
+                ...areaQuery,
+                _error: `Could not find area ${JSON.stringify(dbQuery)} (error: ${err.message})`,
+            }
         })
 }
 
 const promiseCache = Object.create(null)
 
 export default function getArea(
-    { name, type, revision, source, isCustom },
-    { cache = [] }
+    areaQuery: AreaQueryType,
+    { cache = [] }: {cache: any[]}
 ) {
+    const { name, type, revision, source, isCustom } = areaQuery
     let cachedArea = find(
         cache,
         a =>
@@ -83,16 +107,22 @@ export default function getArea(
         return cachedArea
     }
 
-    let id = `{${name}, ${type}, ${revision}}`
+    if (isCustom && source) {
+        return Promise.resolve({
+            ...areaQuery,
+            _area: transform(source),
+        })
+    }
+
+    const id = `{${name}, ${type}, ${revision}}`
     if (id in promiseCache) {
         return promiseCache[id]
     }
 
-    let promise = loadArea({ name, type, revision, source, isCustom })
-
-    promiseCache[id] = promise
+    promiseCache[id] = loadAreaFromDatabase({ name, type, revision, source, isCustom })
 
     return promiseCache[id].then(area => {
+        console.log(area)
         delete promiseCache[id]
         return area
     })

--- a/modules/web/helpers/load-area.js
+++ b/modules/web/helpers/load-area.js
@@ -119,7 +119,12 @@ export default function getArea(
         return promiseCache[id]
     }
 
-    promiseCache[id] = loadAreaFromDatabase({ name, type, revision, source, isCustom })
+    let getAreaFrom = loadAreaFromDatabase
+    if (global.useNetworkOnly) {
+        getAreaFrom = loadAreaFromNetwork
+    }
+
+    promiseCache[id] = getAreaFrom({ name, type, revision, source, isCustom })
 
     return promiseCache[id].then(area => {
         console.log(area)

--- a/modules/web/index.js
+++ b/modules/web/index.js
@@ -19,6 +19,10 @@ startAnalytics()
 
 // Kick off data loading
 import loadData from './helpers/load-data'
+import isSafari from 'is-safari'
+if (isSafari) {
+    global.useNetworkOnly = true
+}
 loadData().catch(err => console.error(err))
 
 // Kick off the GUI


### PR DESCRIPTION
> The proper solution to this would be to fix whatever is telling Safari "you don't need to update any files" in loadData.

This PR:
- adds a dynamic switch based on browser to allow the app to load data from the network instead of the database
- allows pluralizeArea to take any string, instead of just the enumerated ones

This PR allows Safari/Mobile Safari to evaluate _existing_ student files. You will need to export an existing file, then import it into the Safari copy of the app.