### PR TITLE
fix(package): update sto-sis-time-parser to version 2.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "serialize-error": "2.1.0",
     "stabilize": "1.0.0",
     "sto-course-related-data": "4.0.2",
-    "sto-sis-time-parser": "2.2.11",
+    "sto-sis-time-parser": "2.2.13",
     "styled-components": "3.1.6",
     "treo": "0.6.0-rc2",
     "uuid": "3.2.1",


### PR DESCRIPTION
Closes #2149