### PR TITLE
Dep updates, part 1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+modules/web/styles/normalize.scss
+*.md
+*.json
+flow-typed/

--- a/package.json
+++ b/package.json
@@ -19,30 +19,6 @@
         "options": {
           "useTabs": true
         }
-      },
-      {
-        "files": "modules/web/styles/normalize.scss",
-        "options": {
-          "requirePragma": true
-        }
-      },
-      {
-        "files": "*.md",
-        "options": {
-          "requirePragma": true
-        }
-      },
-      {
-        "files": "flow-typed/**/*.js",
-        "options": {
-          "requirePragma": true
-        }
-      },
-      {
-        "files": "package.json",
-        "options": {
-          "requirePragma": true
-        }
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7189,9 +7189,9 @@ sto-course-related-data@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/sto-course-related-data/-/sto-course-related-data-4.0.2.tgz#27bf1ea3e50d709d17760c73c4d773b2a8e1280e"
 
-sto-sis-time-parser@2.2.11:
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/sto-sis-time-parser/-/sto-sis-time-parser-2.2.11.tgz#c1d00cb9ca6cfd03648b8b8feb3ff2d9d248a3a1"
+sto-sis-time-parser@2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/sto-sis-time-parser/-/sto-sis-time-parser-2.2.13.tgz#6f684d42f159fbba6e3f9d2eb6ab84fcd4a49e60"
   dependencies:
     lodash "^4.0.0"
 


### PR DESCRIPTION
Fixes an issue from #2150 that didn't update `yarn.lock` when the package.json got updated.