### PR TITLE
Cleanups

### DIFF
--- a/modules/gob-courses/alter-for-evaluation.js
+++ b/modules/gob-courses/alter-for-evaluation.js
@@ -1,10 +1,7 @@
-import forEach from 'lodash/forEach'
 import toPairs from 'lodash/toPairs'
 import fromPairs from 'lodash/fromPairs'
-import filter from 'lodash/filter'
-import includes from 'lodash/includes'
 
-const whitelist = [
+const whitelist = new Set([
 	'clbid',
 	'credits',
 	'crsid',
@@ -18,18 +15,19 @@ const whitelist = [
 	'semester',
 	'type',
 	'year',
-]
-const mapping = {
-	departments: 'department',
-}
+])
+
+const mapping = new Map([['departments', 'department']])
+
 export function alterForEvaluation(course) {
 	course = {...course}
 
-	forEach(mapping, (toKey, fromKey) => {
-		course[toKey] = course[fromKey]
-	})
+	for (let [fromKey, toKey] of mapping.entries()) {
+		if (course.hasOwnProperty(fromKey)) {
+			course[toKey] = course[fromKey]
+		}
+	}
 
-	let pairs = toPairs(course)
-	pairs = filter(pairs, ([key]) => includes(whitelist, key))
+	let pairs = toPairs(course).filter(([key]) => whitelist.has(key))
 	return fromPairs(pairs)
 }

--- a/modules/gob-examine-student/source/count-credits.js
+++ b/modules/gob-examine-student/source/count-credits.js
@@ -8,6 +8,6 @@ import type {Course} from './types'
  * @param {Course[]} courses - a list of courses
  * @returns {number} - the sum of the 'credits' properties
  */
-export function countCredits(courses: Course[] = []) {
-	return sumBy(courses, 'credits') || 0
+export function countCredits(courses: Array<Course> = []) {
+	return sumBy(courses, c => c.credits) || 0
 }

--- a/modules/gob-object-student/get-active-courses.js
+++ b/modules/gob-object-student/get-active-courses.js
@@ -3,16 +3,6 @@ import filter from 'lodash/filter'
 import flatMap from 'lodash/flatMap'
 
 export function getActiveCourses(student) {
-	/*
-	 - At it's core, this method just needs to get the list of courses that a student has chosen.
-	 - Each schedule has a list of courses that are a part of that schedule.
-	 - Additionally, we only care about the schedules that are marked as "active".
-	 - Keep in mind that each list of courses is actually a *promise* for the courses.
-	 - We also need to make sure to de-duplicate the final list of courses, so that each `clbid` only appears once.
-	 - Finally, remember that a given `clbid` might not exist in the database, in which case we get back 'undefined'.
-	   In this case, we need to know where the `clbid` came from, so that we can render an error in the correct location.
-	 */
-
 	const activeSchedules = filter(student.schedules, s => s.active === true)
 	let courses = flatMap(activeSchedules, s => s.courses)
 	courses = uniqBy(courses.filter(c => c), course => course.clbid)

--- a/modules/gob-object-student/get-active-courses.js
+++ b/modules/gob-object-student/get-active-courses.js
@@ -13,9 +13,9 @@ export function getActiveCourses(student) {
 	   In this case, we need to know where the `clbid` came from, so that we can render an error in the correct location.
 	 */
 
-	const activeSchedules = filter(student.schedules, {active: true})
+	const activeSchedules = filter(student.schedules, s => s.active === true)
 	let courses = flatMap(activeSchedules, s => s.courses)
-	courses = uniqBy(filter(courses, c => c), course => course.clbid)
+	courses = uniqBy(courses.filter(c => c), course => course.clbid)
 
 	return courses
 }

--- a/modules/gob-object-student/student.js
+++ b/modules/gob-object-student/student.js
@@ -185,7 +185,7 @@ export function addCourseToSchedule(student, scheduleId, clbid) {
 		}.${schedule.index})`,
 	)
 
-	schedule.clbids = schedule.clbids.concat(clbid)
+	schedule.clbids = [...schedule.clbids, clbid]
 
 	return Object.assign({}, student, {
 		schedules: Object.assign({}, student.schedules, {

--- a/modules/gob-school-st-olaf-college/deptnums/build-dept-num.js
+++ b/modules/gob-school-st-olaf-college/deptnums/build-dept-num.js
@@ -10,12 +10,7 @@ import {buildDeptString} from './build-dept'
  * @returns {String} - the deptnum string
  */
 export function buildDeptNum(
-	{
-		departments,
-		number,
-		section = '',
-		deptnum,
-	}: {
+	course: {
 		departments: string[],
 		number: number,
 		section?: string,
@@ -23,6 +18,8 @@ export function buildDeptNum(
 	},
 	includeSection?: boolean = false,
 ) {
+	let {departments, number, section = '', deptnum} = course
+
 	const dept = buildDeptString(departments)
 	const deptnumString = deptnum || `${dept} ${number}`
 

--- a/modules/gob-school-st-olaf-college/deptnums/split-dept-num.js
+++ b/modules/gob-school-st-olaf-college/deptnums/split-dept-num.js
@@ -29,10 +29,9 @@ export function splitDeptNum(
 	}
 
 	let deptNum: DeptNum = {
-		departments:
-			matches[1].includes('/')
-				? [matches[2], matches[3]]
-				: [matches[1]],
+		departments: matches[1].includes('/')
+			? [matches[2], matches[3]]
+			: [matches[1]],
 		number: parseInt(matches[4], 10),
 	}
 

--- a/modules/gob-school-st-olaf-college/deptnums/split-dept-num.js
+++ b/modules/gob-school-st-olaf-college/deptnums/split-dept-num.js
@@ -30,7 +30,7 @@ export function splitDeptNum(
 
 	let deptNum: DeptNum = {
 		departments:
-			matches[1].indexOf('/') !== -1
+			matches[1].includes('/')
 				? [matches[2], matches[3]]
 				: [matches[1]],
 		number: parseInt(matches[4], 10),

--- a/modules/gob-search-queries/__tests__/__snapshots__/build-query-from-string.test.js.snap
+++ b/modules/gob-search-queries/__tests__/__snapshots__/build-query-from-string.test.js.snap
@@ -91,16 +91,41 @@ Object {
 
 exports[`buildQueryFromString can also search for deptnums even with no keys 1`] = `
 Object {
-  "deptnum": Array [
-    "ASIAN 220",
+  "departments": Array [
+    "ASIAN",
+  ],
+  "number": Array [
+    220,
   ],
 }
 `;
 
 exports[`buildQueryFromString can also search for deptnums with sections even with no keys 1`] = `
 Object {
-  "deptnum": Array [
-    "ASIAN/REL 220",
+  "departments": Array [
+    "$AND",
+    "ASIAN",
+    "REL",
+  ],
+  "number": Array [
+    220,
+  ],
+  "section": Array [
+    "A",
+  ],
+}
+`;
+
+exports[`buildQueryFromString conjoins a deptnum and a department key 1`] = `
+Object {
+  "departments": Array [
+    "$AND",
+    "MUSIC",
+    "ART",
+    "ASIAN",
+  ],
+  "number": Array [
+    102,
   ],
 }
 `;
@@ -115,8 +140,11 @@ Object {
 
 exports[`buildQueryFromString handles a single key and no value 1`] = `
 Object {
-  "deptnum": Array [
-    "ENGL 200",
+  "departments": Array [
+    "ENGL",
+  ],
+  "number": Array [
+    200,
   ],
 }
 `;
@@ -145,6 +173,22 @@ Object {
 `;
 
 exports[`buildQueryFromString handles no arguments as an empty string 1`] = `Object {}`;
+
+exports[`buildQueryFromString ignores subsequent deptnums in a non-keyed query 1`] = `
+Object {
+  "departments": Array [
+    "$AND",
+    "ASIAN",
+    "REL",
+  ],
+  "number": Array [
+    220,
+  ],
+  "section": Array [
+    "A",
+  ],
+}
+`;
 
 exports[`buildQueryFromString infers $AND from a list of multiple things 1`] = `
 Object {
@@ -214,8 +258,16 @@ Object {
     "$OR",
     1,
     0.25,
-    0.25,
+  ],
+}
+`;
+
+exports[`buildQueryFromString removes duplicate values for a key 1`] = `
+Object {
+  "credits": Array [
+    "$OR",
     1,
+    0.25,
   ],
 }
 `;

--- a/modules/gob-search-queries/__tests__/build-query-from-string.test.js
+++ b/modules/gob-search-queries/__tests__/build-query-from-string.test.js
@@ -72,7 +72,11 @@ describe('buildQueryFromString', () => {
 
 		let actual = buildQueryFromString(query)
 		expect(actual).toMatchSnapshot()
-		expect(actual).toEqual({departments: ['$AND', 'ASIAN', 'REL'], number: [220], section: ['A']})
+		expect(actual).toEqual({
+			departments: ['$AND', 'ASIAN', 'REL'],
+			number: [220],
+			section: ['A'],
+		})
 	})
 
 	it('returns an empty object when given nothing but whitespace', () => {

--- a/modules/gob-search-queries/__tests__/build-query-from-string.test.js
+++ b/modules/gob-search-queries/__tests__/build-query-from-string.test.js
@@ -34,6 +34,14 @@ describe('buildQueryFromString', () => {
 		expect(buildQueryFromString(query)).toMatchSnapshot()
 	})
 
+	it('conjoins a deptnum and a department key', () => {
+		// note: it's debatable as to what we want here; this test is just for
+		// documentation.
+
+		let query = 'AR/AS 102 department: MUSIC'
+		expect(buildQueryFromString(query)).toMatchSnapshot()
+	})
+
 	it('builds a query string while deduplicating synonyms of keys', () => {
 		let query =
 			'ges: $AND  geneds: history of western culture gened: HBS  semester: Spring  year: 2014'
@@ -57,6 +65,14 @@ describe('buildQueryFromString', () => {
 		let query = 'AS/RE 220A'
 
 		expect(buildQueryFromString(query)).toMatchSnapshot()
+	})
+
+	it('ignores subsequent deptnums in a non-keyed query', () => {
+		let query = 'AS/RE 220A AMCON 102'
+
+		let actual = buildQueryFromString(query)
+		expect(actual).toMatchSnapshot()
+		expect(actual).toEqual({departments: ['$AND', 'ASIAN', 'REL'], number: [220], section: ['A']})
 	})
 
 	it('returns an empty object when given nothing but whitespace', () => {
@@ -132,6 +148,15 @@ describe('buildQueryFromString', () => {
 			'credits: $OR credits: 1.0 credits: 0.25 credits: .25 credits: 1'
 
 		expect(buildQueryFromString(query)).toMatchSnapshot()
+	})
+
+	it('removes duplicate values for a key', () => {
+		let query =
+			'credits: $OR credits: 1.0 credits: 0.25 credits: .25 credits: 1'
+
+		let actual = buildQueryFromString(query)
+		expect(actual).toMatchSnapshot()
+		expect(actual.credits).toEqual(['$OR', 1, 0.25])
 	})
 
 	it('turns pf from a "true" string into a boolean', () => {

--- a/modules/gob-search-queries/__tests__/check-course-against-query.test.js
+++ b/modules/gob-search-queries/__tests__/check-course-against-query.test.js
@@ -117,55 +117,55 @@ describe('checkCourseAgainstQuery', () => {
 	})
 
 	it('handles lowercases the checked value for substring matches', () => {
-		const query = {title: 'needle'}
+		const query = {title: ['needle']}
 		const course = {title: 'NEEDLE'}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 	})
 
 	it('handles substring matches on "title"', () => {
-		const query = {title: 'needle'}
+		const query = {title: ['needle']}
 		const course = {title: 'needle in a haystack'}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {title: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "name"', () => {
-		const query = {name: 'needle'}
+		const query = {name: ['needle']}
 		const course = {name: 'needle in a haystack'}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {name: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "description"', () => {
-		const query = {description: 'needle'}
+		const query = {description: ['needle']}
 		const course = {description: 'needle in a haystack'}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {description: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "notes"', () => {
-		const query = {notes: 'needle'}
+		const query = {notes: ['needle']}
 		const course = {notes: 'needle in a haystack'}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {notes: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "instructors"', () => {
-		const query = {instructors: 'needle'}
+		const query = {instructors: ['needle']}
 		const course = {instructors: ['Haystack, Needle III']}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {instructors: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "times"', () => {
-		const query = {times: '300'}
+		const query = {times: ['300']}
 		const course = {times: ['1200-300pm']}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {times: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
 	it('handles substring matches on "locations"', () => {
-		const query = {locations: '250A'}
+		const query = {locations: ['250A']}
 		const course = {locations: ['CHM 250A']}
 		expect(checkCourseAgainstQuery(query, course)).toBe(true)
 		const falsecourse = {locations: '… in a haystack'}

--- a/modules/gob-search-queries/__tests__/check-course-against-query.test.js
+++ b/modules/gob-search-queries/__tests__/check-course-against-query.test.js
@@ -129,6 +129,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {title: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "name"', () => {
 		const query = {name: ['needle']}
 		const course = {name: 'needle in a haystack'}
@@ -136,6 +137,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {name: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "description"', () => {
 		const query = {description: ['needle']}
 		const course = {description: 'needle in a haystack'}
@@ -143,6 +145,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {description: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "notes"', () => {
 		const query = {notes: ['needle']}
 		const course = {notes: 'needle in a haystack'}
@@ -150,6 +153,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {notes: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "instructors"', () => {
 		const query = {instructors: ['needle']}
 		const course = {instructors: ['Haystack, Needle III']}
@@ -157,6 +161,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {instructors: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "times"', () => {
 		const query = {times: ['300']}
 		const course = {times: ['1200-300pm']}
@@ -164,6 +169,7 @@ describe('checkCourseAgainstQuery', () => {
 		const falsecourse = {times: '… in a haystack'}
 		expect(checkCourseAgainstQuery(query, falsecourse)).toBe(false)
 	})
+
 	it('handles substring matches on "locations"', () => {
 		const query = {locations: ['250A']}
 		const course = {locations: ['CHM 250A']}

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -131,8 +131,8 @@ function organizeValues([key, values], words = false, profWords = false) {
 }
 
 export function buildQueryFromString(queryString = '', opts = {}) {
-	queryString = trim(queryString)
-	if (endsWith(queryString, ':')) {
+	queryString = queryString.trim()
+	if (queryString.endsWith(':')) {
 		queryString = queryString.substring(0, queryString.length - 1)
 	}
 
@@ -150,7 +150,7 @@ export function buildQueryFromString(queryString = '', opts = {}) {
 	let matches = queryString.split(rex)
 
 	// Remove extra whitespace and remove empty strings
-	let cleaned = filter(map(matches, trim), str => str.length > 0)
+	let cleaned = matches.map(s => s.trim()).filter(s => s.length > 0)
 
 	// Grab the keys and values from the lists
 	let [keys, values] = partitionByIndex(cleaned)
@@ -169,7 +169,7 @@ export function buildQueryFromString(queryString = '', opts = {}) {
 	keys = map(keys, key => {
 		key = key.toLowerCase()
 		/* istanbul ignore else */
-		if (!startsWith(key, '_')) {
+		if (!key.startsWith('_')) {
 			key = keywordMappings[key] || key
 		}
 		return key
@@ -180,7 +180,7 @@ export function buildQueryFromString(queryString = '', opts = {}) {
 
 	// Perform initial cleaning of the values, dependent on the keys
 	let paired = unzip(
-		map(toPairs(zipped), kvpairs =>
+		toPairs(zipped).map(kvpairs =>
 			organizeValues(kvpairs, opts.words, opts.profWords),
 		),
 	)

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -213,7 +213,9 @@ export function buildQueryFromString(
 		}
 
 		// find the first boolean value in the thing
-		let booleanIndex = val.findIndex(v => typeof v === 'string' && v.startsWith('$'))
+		let booleanIndex = val.findIndex(
+			v => typeof v === 'string' && v.startsWith('$'),
+		)
 		let includesBoolean = booleanIndex !== -1
 		let startsWithBoolean = booleanIndex === 0
 

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -154,8 +154,19 @@ export function buildQueryFromString(
 
 	if (stringThing && quacksLikeDeptNum(stringThing)) {
 		let {departments, number, section} = splitDeptNum(stringThing, true)
-		keys.push('departments')
-		values.push(departments)
+
+		if (departments.length === 1) {
+			keys.push('departments')
+			values.push(departments[0])
+		} else {
+			keys.push('departments')
+			values.push('$AND')
+			for (let dept of departments) {
+				keys.push('departments')
+				values.push(dept)
+			}
+		}
+
 		keys.push('number')
 		values.push(number)
 		if (section) {

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -198,7 +198,8 @@ export function buildQueryFromString(
 		val = flatten(val)
 
 		// if it's a multi-value thing and doesn't include a boolean yet, default to $AND
-		if (val.length > 1 && !startsWith(val[0], '$')) {
+		let startsWithBoolean = typeof val[0] === 'string' && /^\$/.test(val[0])
+		if (val.length > 1 && !startsWithBoolean) {
 			val.unshift('$AND')
 		}
 

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -9,11 +9,7 @@ import toPairs from 'lodash/toPairs'
 import trim from 'lodash/trim'
 import unzip from 'lodash/unzip'
 
-import {
-	quacksLikeDeptNum,
-	splitDeptNum,
-	buildDeptNum,
-} from '@gob/school-st-olaf-college'
+import {quacksLikeDeptNum, splitDeptNum} from '@gob/school-st-olaf-college'
 
 import {partitionByIndex, splitParagraph, zipToObjectWithArrays} from '@gob/lib'
 

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -163,9 +163,7 @@ export function buildQueryFromString(
 			values.push(section)
 		}
 	} else if (stringThing) {
-		keys.push('title')
-		values.push(stringThing)
-		keys.push('name')
+		keys.push('words')
 		values.push(stringThing)
 	}
 

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -130,7 +130,10 @@ function organizeValues([key, values], words = false, profWords = false) {
 	return [key, organizedValues]
 }
 
-export function buildQueryFromString(queryString = '', opts = {}) {
+export function buildQueryFromString(
+	queryString: string = '',
+	opts: {words?: boolean, profWords?: boolean} = {},
+) {
 	queryString = queryString.trim()
 	if (queryString.endsWith(':')) {
 		queryString = queryString.substring(0, queryString.length - 1)

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -163,6 +163,8 @@ export function buildQueryFromString(queryString = '', opts = {}) {
 	} else if (stringThing) {
 		keys.push('title')
 		values.push(stringThing)
+		keys.push('name')
+		values.push(stringThing)
 	}
 
 	// Process the keys, to clean them up somewhat

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -156,10 +156,15 @@ export function buildQueryFromString(queryString = '', opts = {}) {
 	let [keys, values] = partitionByIndex(cleaned)
 
 	if (stringThing && quacksLikeDeptNum(stringThing)) {
-		let {departments, number} = splitDeptNum(stringThing)
-		let deptnum = buildDeptNum({departments, number})
-		keys.push('deptnum')
-		values.push(deptnum)
+		let {departments, number, section} = splitDeptNum(stringThing, true)
+		keys.push('departments')
+		values.push(departments)
+		keys.push('number')
+		values.push(number)
+		if (section) {
+			keys.push('section')
+			values.push(section)
+		}
 	} else if (stringThing) {
 		keys.push('title')
 		values.push(stringThing)

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -82,11 +82,9 @@ function organizeValues([key, values], words = false, profWords = false) {
 		} else if (key === 'semester') {
 			val = val.toLowerCase()
 			val = semesters[val] || parseInt(val, 10)
-		} else if (key === 'instructors') {
-			if (profWords) {
-				val = splitParagraph(val)
-				key = 'profWords'
-			}
+		} else if (key === 'instructors' && profWords) {
+			val = splitParagraph(val)
+			key = 'profWords'
 		} else if (key === 'times' || key === 'locations') {
 			val = val.toUpperCase()
 		} else if (key === 'pf') {

--- a/modules/gob-search-queries/build-query-from-string.js
+++ b/modules/gob-search-queries/build-query-from-string.js
@@ -1,12 +1,10 @@
-import endsWith from 'lodash/endsWith'
-import filter from 'lodash/filter'
+// @flow
+
+import flatMap from 'lodash/flatMap'
 import flatten from 'lodash/flatten'
-import includes from 'lodash/includes'
 import map from 'lodash/map'
 import mapValues from 'lodash/mapValues'
-import startsWith from 'lodash/startsWith'
 import toPairs from 'lodash/toPairs'
-import trim from 'lodash/trim'
 import unzip from 'lodash/unzip'
 
 import {quacksLikeDeptNum, splitDeptNum} from '@gob/school-st-olaf-college'

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -44,15 +44,20 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 		// dept, gereqs, etc.
 		if (Array.isArray(course[key]) && !substring) {
 			return course[key].includes(val)
-		} else if (Array.isArray(course[key]) && substring) {
-			return some(
-				map(course[key], item =>
-					item.toLowerCase().includes(val.toLowerCase()),
-				),
-			)
-		} else if (substring) {
-			return course[key].toLowerCase().includes(val.toLowerCase())
 		}
+
+		if (Array.isArray(course[key]) && substring) {
+			val = val.toLowerCase()
+			return course[key]
+				.map(item => item.toLowerCase().includes(val))
+				.some(v => v === true)
+		}
+
+		if (substring) {
+			val = val.toLowerCase()
+			return course[key].toLowerCase().includes(val)
+		}
+
 		return course[key] === val
 	})
 

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,7 +1,6 @@
 import compact from 'lodash/compact'
 import every from 'lodash/every'
 import includes from 'lodash/includes'
-import indexOf from 'lodash/indexOf'
 import isArray from 'lodash/isArray'
 import map from 'lodash/map'
 import size from 'lodash/size'
@@ -32,7 +31,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 	// - an $AND, $OR, $NOT, $NOR, or $XOR query
 	// - one of the above, but substring
 
-	let hasBool = indexOf(values[0], '$') === 0
+	let hasBool = typeof values[0] === 'string' && values[0].startsWith('$')
 	let OR = values[0] === '$OR'
 	let NOR = values[0] === '$NOR'
 	let AND = values[0] === '$AND'

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -35,8 +35,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 	let XOR = values[0] === '$XOR'
 
 	if (hasBool) {
-		// remove the first value from the array
-		// by returning all but the first element
+		// remove the first value from the array by returning all but the first element
 		values = values.slice(1)
 	}
 

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,3 +1,5 @@
+// @flow
+
 import toPairs from 'lodash/toPairs'
 
 const isTrue = x => x === true
@@ -12,7 +14,10 @@ const SUBSTRING_KEYS = new Set([
 	'locations',
 ])
 
-function checkQueryBit(course, [key, values]) {
+type Query = {[key: string]: mixed}
+type Course = {[key: string]: mixed}
+
+function checkQueryBit(course: Course, [key: string, values: Array<mixed>]) {
 	if (!course.hasOwnProperty(key)) {
 		return false
 	}
@@ -36,22 +41,28 @@ function checkQueryBit(course, [key, values]) {
 		values = values.slice(1)
 	}
 
+	let courseValue = course[key]
+
 	let internalMatches = values.map(val => {
 		// dept, gereqs, etc.
-		if (Array.isArray(course[key])) {
+		if (Array.isArray(courseValue)) {
 			if (substringMatch) {
 				val = val.toLowerCase()
-				return course[key].some(item => item.toLowerCase().includes(val))
+				return courseValue.some(
+					item =>
+						typeof item === 'string' &&
+						item.toLowerCase().includes(val),
+				)
 			} else {
-				return course[key].includes(val)
+				return courseValue.includes(val)
 			}
 		}
 
-		if (substringMatch) {
+		if (substringMatch && typeof courseValue === 'string') {
 			val = val.toLowerCase()
-			return course[key].toLowerCase().includes(val)
+			return courseValue.toLowerCase().includes(val)
 		} else {
-			return course[key] === val
+			return courseValue === val
 		}
 	})
 
@@ -74,6 +85,6 @@ function checkQueryBit(course, [key, values]) {
 // query: Object | the query object that comes out of buildQueryFromString
 // course: Course | the course to check
 // returns: Boolean | did all query bits pass the check?
-export function checkCourseAgainstQuery(query, course) {
+export function checkCourseAgainstQuery(query: Query, course: Course): boolean {
 	return toPairs(query).every(pair => checkQueryBit(course, pair))
 }

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,6 +1,5 @@
 import compact from 'lodash/compact'
 import every from 'lodash/every'
-import has from 'lodash/has'
 import includes from 'lodash/includes'
 import indexOf from 'lodash/indexOf'
 import isArray from 'lodash/isArray'
@@ -22,7 +21,7 @@ const SUBSTRING_KEYS = new Set([
 ])
 
 function checkCourseAgainstQueryBit(course, [key, values]) {
-	if (!has(course, key)) {
+	if (!course.hasOwnProperty(key)) {
 		return false
 	}
 

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -5,7 +5,6 @@ import isArray from 'lodash/isArray'
 import map from 'lodash/map'
 import size from 'lodash/size'
 import some from 'lodash/some'
-import tail from 'lodash/tail'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
 
@@ -41,7 +40,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 	if (hasBool) {
 		// remove the first value from the array
 		// by returning all but the first element
-		values = tail(values)
+		values = values.slice(1)
 	}
 
 	let internalMatches = map(values, val => {

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,9 +1,9 @@
-import compact from 'lodash/compact'
-import every from 'lodash/every'
 import map from 'lodash/map'
-import some from 'lodash/some'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
+
+const isTrue = x => x === true
+const isTruthy = x => Boolean(x)
 
 const SUBSTRING_KEYS = new Set([
 	'title',
@@ -49,7 +49,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 			val = val.toLowerCase()
 			return course[key]
 				.map(item => item.toLowerCase().includes(val))
-				.some(v => v === true)
+				.some(isTrue)
 		}
 
 		if (substring) {
@@ -61,16 +61,16 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 	})
 
 	if (!hasBool) {
-		return every(internalMatches)
+		return internalMatches.every(isTrue)
 	}
 
 	let result = false
 
-	if (OR) result = some(internalMatches)
-	if (NOR) result = !some(internalMatches)
-	if (AND) result = every(internalMatches)
-	if (NOT) result = !every(internalMatches)
-	if (XOR) result = compact(internalMatches).length === 1
+	if (OR) result = internalMatches.some(isTrue)
+	if (NOR) result = !internalMatches.some(isTrue)
+	if (AND) result = internalMatches.every(isTrue)
+	if (NOT) result = !internalMatches.every(isTrue)
+	if (XOR) result = internalMatches.filter(isTrue).length === 1
 
 	return result
 }
@@ -85,5 +85,5 @@ export function checkCourseAgainstQuery(query, course) {
 		checkCourseAgainstQueryBit(course, pair),
 	)
 
-	return kvPairs.length === matches.length && every(matches)
+	return kvPairs.length === matches.length && matches.every(isTruthy)
 }

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,6 +1,5 @@
 import compact from 'lodash/compact'
 import every from 'lodash/every'
-import includes from 'lodash/includes'
 import map from 'lodash/map'
 import size from 'lodash/size'
 import some from 'lodash/some'
@@ -45,15 +44,15 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 	let internalMatches = map(values, val => {
 		// dept, gereqs, etc.
 		if (Array.isArray(course[key]) && !substring) {
-			return includes(course[key], val)
+			return course[key].includes(val)
 		} else if (Array.isArray(course[key]) && substring) {
 			return some(
 				map(course[key], item =>
-					includes(item.toLowerCase(), val.toLowerCase()),
+					item.toLowerCase().includes(val.toLowerCase()),
 				),
 			)
 		} else if (substring) {
-			return includes(course[key].toLowerCase(), val.toLowerCase())
+			return course[key].toLowerCase().includes(val.toLowerCase())
 		}
 		return course[key] === val
 	})

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,4 +1,3 @@
-import map from 'lodash/map'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
 
@@ -39,7 +38,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 		values = values.slice(1)
 	}
 
-	let internalMatches = map(values, val => {
+	let internalMatches = values.map(val => {
 		// dept, gereqs, etc.
 		if (Array.isArray(course[key]) && !substring) {
 			return course[key].includes(val)

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,7 +1,6 @@
 import compact from 'lodash/compact'
 import every from 'lodash/every'
 import includes from 'lodash/includes'
-import isArray from 'lodash/isArray'
 import map from 'lodash/map'
 import size from 'lodash/size'
 import some from 'lodash/some'
@@ -45,9 +44,9 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 
 	let internalMatches = map(values, val => {
 		// dept, gereqs, etc.
-		if (isArray(course[key]) && !substring) {
+		if (Array.isArray(course[key]) && !substring) {
 			return includes(course[key], val)
-		} else if (isArray(course[key]) && substring) {
+		} else if (Array.isArray(course[key]) && substring) {
 			return some(
 				map(course[key], item =>
 					includes(item.toLowerCase(), val.toLowerCase()),

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -46,9 +46,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 
 		if (Array.isArray(course[key]) && substring) {
 			val = val.toLowerCase()
-			return course[key]
-				.map(item => item.toLowerCase().includes(val))
-				.some(isTrue)
+			return course[key].some(item => item.toLowerCase().includes(val))
 		}
 
 		if (substring) {

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -11,12 +11,22 @@ import tail from 'lodash/tail'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
 
+const SUBSTRING_KEYS = new Set([
+	'title',
+	'name',
+	'description',
+	'notes',
+	'instructors',
+	'times',
+	'locations',
+])
+
 function checkCourseAgainstQueryBit(course, [key, values]) {
 	if (!has(course, key)) {
 		return false
 	}
 
-	let substring = false
+	let substring = SUBSTRING_KEYS.has(key)
 
 	// values is either:
 	// - a 1-long array
@@ -34,23 +44,6 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 		// remove the first value from the array
 		// by returning all but the first element
 		values = tail(values)
-	}
-
-	if (
-		includes(
-			[
-				'title',
-				'name',
-				'description',
-				'notes',
-				'instructors',
-				'times',
-				'locations',
-			],
-			key,
-		)
-	) {
-		substring = true
 	}
 
 	let internalMatches = map(values, val => {

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,7 +1,6 @@
 import compact from 'lodash/compact'
 import every from 'lodash/every'
 import map from 'lodash/map'
-import size from 'lodash/size'
 import some from 'lodash/some'
 import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
@@ -82,5 +81,5 @@ export function checkCourseAgainstQuery(query, course) {
 		checkCourseAgainstQueryBit(course, pair),
 	)
 
-	return size(kvPairs) === size(matches) && every(matches)
+	return kvPairs.length === matches.length && every(matches)
 }

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -17,12 +17,12 @@ function checkQueryBit(course, [key, values]) {
 		return false
 	}
 
-	let substring = SUBSTRING_KEYS.has(key)
+	let substringMatch = SUBSTRING_KEYS.has(key)
 
 	// values is either:
 	// - a 1-long array
 	// - an $AND, $OR, $NOT, $NOR, or $XOR query
-	// - one of the above, but substring
+	// - one of the above, but substringMatch
 
 	let hasBool = typeof values[0] === 'string' && values[0].startsWith('$')
 	let OR = values[0] === '$OR'
@@ -38,21 +38,21 @@ function checkQueryBit(course, [key, values]) {
 
 	let internalMatches = values.map(val => {
 		// dept, gereqs, etc.
-		if (Array.isArray(course[key]) && !substring) {
-			return course[key].includes(val)
+		if (Array.isArray(course[key])) {
+			if (substringMatch) {
+				val = val.toLowerCase()
+				return course[key].some(item => item.toLowerCase().includes(val))
+			} else {
+				return course[key].includes(val)
+			}
 		}
 
-		if (Array.isArray(course[key]) && substring) {
-			val = val.toLowerCase()
-			return course[key].some(item => item.toLowerCase().includes(val))
-		}
-
-		if (substring) {
+		if (substringMatch) {
 			val = val.toLowerCase()
 			return course[key].toLowerCase().includes(val)
+		} else {
+			return course[key] === val
 		}
-
-		return course[key] === val
 	})
 
 	if (!hasBool) {

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -12,7 +12,7 @@ const SUBSTRING_KEYS = new Set([
 	'locations',
 ])
 
-function checkCourseAgainstQueryBit(course, [key, values]) {
+function checkQueryBit(course, [key, values]) {
 	if (!course.hasOwnProperty(key)) {
 		return false
 	}
@@ -75,7 +75,5 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 // course: Course | the course to check
 // returns: Boolean | did all query bits pass the check?
 export function checkCourseAgainstQuery(query, course) {
-	return toPairs(query).every(pair =>
-		checkCourseAgainstQueryBit(course, pair),
-	)
+	return toPairs(query).every(pair => checkQueryBit(course, pair))
 }

--- a/modules/gob-search-queries/check-course-against-query.js
+++ b/modules/gob-search-queries/check-course-against-query.js
@@ -1,8 +1,6 @@
-import takeWhile from 'lodash/takeWhile'
 import toPairs from 'lodash/toPairs'
 
 const isTrue = x => x === true
-const isTruthy = x => Boolean(x)
 
 const SUBSTRING_KEYS = new Set([
 	'title',
@@ -77,10 +75,7 @@ function checkCourseAgainstQueryBit(course, [key, values]) {
 // course: Course | the course to check
 // returns: Boolean | did all query bits pass the check?
 export function checkCourseAgainstQuery(query, course) {
-	let kvPairs = toPairs(query)
-	let matches = takeWhile(kvPairs, pair =>
+	return toPairs(query).every(pair =>
 		checkCourseAgainstQueryBit(course, pair),
 	)
-
-	return kvPairs.length === matches.length && matches.every(isTruthy)
 }

--- a/modules/gob-web/helpers/fulfill-fulfillments.js
+++ b/modules/gob-web/helpers/fulfill-fulfillments.js
@@ -3,18 +3,20 @@ import props from 'p-props'
 import {getCourse} from './get-courses'
 import {alterCourse} from './alter-course-for-evaluation'
 
-export function fulfillFulfillments(student, {cache = []}) {
+export async function fulfillFulfillments(
+	student,
+	{store = Object.create(null)},
+) {
 	let promises = mapValues(
 		student.fulfillments,
-		clbid => cache[clbid] || getCourse({clbid}, student.fabrications),
+		clbid => store[clbid] || getCourse({clbid}, student.fabrications),
 	)
-	return props(promises).then(result =>
-		mapValues(result, r => {
-			return {
-				$type: 'course',
-				$course: alterCourse(r),
-				_isFulfillment: true,
-			}
-		}),
-	)
+
+	let result = await props(promises)
+
+	return mapValues(result, r => ({
+		$type: 'course',
+		$course: alterCourse(r),
+		_isFulfillment: true,
+	}))
 }

--- a/modules/gob-web/helpers/get-courses.js
+++ b/modules/gob-web/helpers/get-courses.js
@@ -1,7 +1,6 @@
 // @flow
 import {db} from './db'
 import omit from 'lodash/omit'
-import padStart from 'lodash/padStart'
 import {status, json} from '@gob/lib'
 
 const baseUrl = 'https://stodevx.github.io/course-data'
@@ -11,7 +10,7 @@ export function getCourseFromNetwork(clbid: number) {
 		return networkCache[clbid]
 	}
 
-	const id = padStart(clbid.toString(), 10, '0')
+	const id = clbid.toString().padStart(10, '0')
 	const dir = (Math.floor(clbid / 1000) * 1000).toString()
 
 	const path = `${baseUrl}/courses/${dir}/${id}.json`

--- a/modules/gob-web/helpers/get-student-data.js
+++ b/modules/gob-web/helpers/get-student-data.js
@@ -3,22 +3,23 @@ import {embedActiveStudentCourses} from './embed-active-student-courses'
 import {getStudentStudies} from './get-student-studies'
 import {fulfillFulfillments} from './fulfill-fulfillments'
 
-export function getStudentData(student, {areas, courses}) {
-	const promisedAreas = getStudentStudies(student, {cache: areas})
-	const promisedSchedules = embedActiveStudentCourses(student, {
-		cache: courses,
-	})
-	const promisedFulfillments = fulfillFulfillments(student, {
+// @throws
+export async function getStudentData(student, {areas, courses}) {
+	let promisedAreas = getStudentStudies(student, {cache: areas})
+
+	let promisedSchedules = embedActiveStudentCourses(student, {
 		cache: courses,
 	})
 
-	return props({
+	let promisedFulfillments = fulfillFulfillments(student, {
+		cache: courses,
+	})
+
+	let data = await props({
 		areas: promisedAreas,
 		schedules: promisedSchedules,
 		fulfilled: promisedFulfillments,
 	})
-		.then(data => ({...student, ...data}))
-		.catch(err => {
-			throw err
-		})
+
+	return {...student, ...data}
 }

--- a/modules/gob-web/modules/area-of-study/expression.js
+++ b/modules/gob-web/modules/area-of-study/expression.js
@@ -68,7 +68,11 @@ function makeModifierExpression({expr}) {
 	const op = humanizeOperator(expr.$count.$operator)
 	const num = expr.$count.$num
 	const needs = `${op} ${num} ${plur(expr.$what, expr.$count.$num)}`
-	const description = `${expr._counted} of ${needs} from ${expr.$from}`
+	let from = expr.$from
+	if (expr.$from === 'where') {
+		from = 'courses where ' + makeWhereQualifier(expr.$where)
+	}
+	const description = `${expr._counted} of ${needs} from ${from}`
 	return {description}
 }
 

--- a/modules/gob-web/modules/course-searcher/course-searcher-options.js
+++ b/modules/gob-web/modules/course-searcher/course-searcher-options.js
@@ -18,3 +18,8 @@ export const GROUP_BY = {
 	year: 'Year',
 	none: 'None',
 }
+
+export const sortByOptions: Array<string> = (Object.values(SORT_BY): Array<any>)
+export const groupByOptions: Array<string> = (Object.values(GROUP_BY): Array<
+	any,
+>)

--- a/modules/gob-web/modules/course-searcher/course-searcher.js
+++ b/modules/gob-web/modules/course-searcher/course-searcher.js
@@ -1,16 +1,16 @@
 // @flow
 import React from 'react'
 
-import map from 'lodash/map'
 import {toPrettyTerm} from '@gob/school-st-olaf-college'
 
+import {LabelledSelect} from './labelled-select'
 import Button from '../../components/button'
 import Icon from '../../components/icon'
 import Loading from '../../components/loading'
 import CourseResultsList from './course-results-list'
 import {androidArrowForward} from '../../icons/ionicons'
 
-import {SORT_BY, GROUP_BY} from './course-searcher-options'
+import {sortByOptions, groupByOptions} from './course-searcher-options'
 
 import './course-searcher.scss'
 
@@ -106,17 +106,19 @@ export default function CourseSearcher(props: CourseSearcherProps) {
 						Close
 					</Button>
 				</div>
+
 				<div className="row">
 					<input
 						type="search"
 						className="search-box"
 						value={query}
-						placeholder={'Search for a course or phrase'}
+						placeholder="Search for a course or phrase"
 						onChange={onQueryChange}
 						onKeyDown={onKeyDown}
 						autoFocus={true}
 					/>
 				</div>
+
 				<div className="row submit">
 					<Button
 						className="submit-search-query"
@@ -125,48 +127,34 @@ export default function CourseSearcher(props: CourseSearcherProps) {
 						onClick={onQuerySubmit}
 						disabled={inProgress}
 					>
-						{inProgress
-							? [<span key="msg">Searching…</span>]
-							: [
-									<span key="msg">Search </span>,
-									<Icon key="icon">
-										{androidArrowForward}
-									</Icon>,
-							  ]}
+						{inProgress ? (
+							<span key="msg">Searching…</span>
+						) : (
+							<React.Fragment>
+								<span>Search </span>
+								<Icon>{androidArrowForward}</Icon>
+							</React.Fragment>
+						)}
 					</Button>
 				</div>
+
 				{hasQueried && (
 					<div className="row search-filters">
-						<span className="filter">
-							<label htmlFor="sort">Sort by:</label>
-							<br />
-							<select
-								id="sort"
-								value={sortBy}
-								onChange={onSortChange}
-							>
-								{map(SORT_BY, opt => (
-									<option key={opt} value={opt}>
-										{opt}
-									</option>
-								))}
-							</select>
-						</span>
-						<span className="filter">
-							<label htmlFor="group">Group by:</label>
-							<br />
-							<select
-								id="group"
-								value={groupBy}
-								onChange={onGroupByChange}
-							>
-								{map(GROUP_BY, opt => (
-									<option key={opt} value={opt}>
-										{opt}
-									</option>
-								))}
-							</select>
-						</span>
+						<LabelledSelect
+							className="filter"
+							label="Sort by:"
+							options={sortByOptions}
+							onChange={onSortChange}
+							value={sortBy}
+						/>
+
+						<LabelledSelect
+							className="filter"
+							label="Group by:"
+							options={groupByOptions}
+							onChange={onGroupByChange}
+							value={groupBy}
+						/>
 					</div>
 				)}
 			</header>

--- a/modules/gob-web/modules/course-searcher/course-searcher.scss
+++ b/modules/gob-web/modules/course-searcher/course-searcher.scss
@@ -57,6 +57,7 @@
 	&:focus {
 		background-color: $blue-50;
 		color: $blue-900;
+
 		&::-webkit-input-placeholder {
 			color: desaturate($light-blue-300, 75%);
 		}
@@ -133,9 +134,19 @@
 .search-filters .filter {
 	flex: 1;
 	text-align: center;
+
+	&:not(:last-child) {
+		margin-right: 0.25em;
+	}
 }
 
-.search-filters label {
+.search-filters .filter label {
 	font-size: 0.9em;
 	font-weight: 500;
+
+	display: block;
+}
+
+.search-filters .filter select {
+	width: 100%;
 }

--- a/modules/gob-web/modules/course-searcher/labelled-select.js
+++ b/modules/gob-web/modules/course-searcher/labelled-select.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react'
+
+import uniqueId from 'lodash/uniqueId'
+
+export function LabelledSelect(props: {
+	onChange: (ev: SyntheticInputEvent<HTMLSelectElement>) => void,
+	value: string,
+	label: string,
+	options: Array<string>,
+	className: string,
+}) {
+	let {className, onChange, value, label, options} = props
+	let id = `labelled-select-${uniqueId()}`
+
+	return (
+		<span className={className}>
+			<label htmlFor={id}>{label}</label>
+
+			<select id={id} value={value} onChange={onChange}>
+				{options.map(opt => (
+					<option key={opt} value={opt}>
+						{opt}
+					</option>
+				))}
+			</select>
+		</span>
+	)
+}

--- a/modules/gob-web/modules/course-table/course-list.js
+++ b/modules/gob-web/modules/course-table/course-list.js
@@ -43,9 +43,9 @@ const Empty = styled(EmptyCourseSlot)`
 
 type Props = {
 	courses: Array<Object>,
-	availableCredits: number,
+	usedSlots: number,
 	conflicts: Object[],
-	creditCount: number,
+	maxSlots: number,
 	schedule: Object,
 	studentId: string,
 }
@@ -66,10 +66,14 @@ export default function CourseList(props: Props) {
 			),
 	)
 
-	const usedCredits = Math.floor(props.creditCount)
-	const emptySlots = range(usedCredits, props.availableCredits)
-		.filter(n => n >= 0)
-		.map(n => <Empty key={n} />)
+	if (props.usedSlots < 0 || props.maxSlots < 0) {
+		throw new Error('usedSlots and maxSlots must be >= 0')
+	}
+
+	let usedSlots = Math.floor(props.usedSlots)
+	let emptySlots =
+		usedSlots < props.maxSlots ? range(usedSlots, props.maxSlots) : []
+	emptySlots = emptySlots.map(n => <Empty key={n} />)
 
 	return (
 		<List className="course-list">

--- a/modules/gob-web/modules/course-table/semester.js
+++ b/modules/gob-web/modules/course-table/semester.js
@@ -106,12 +106,16 @@ function Semester(props) {
 	const {courses, conflicts, hasConflict} = schedule
 
 	// `recommendedCredits` is 4 for fall/spring and 1 for everything else
-	const recommendedCredits = semester === 1 || semester === 3 ? 4 : 1
-	const currentCredits = courses && courses.length ? countCredits(courses) : 0
+	const creditsPerCourse = 1
+	const recommendedCredits =
+		semester === 1 || semester === 3
+			? creditsPerCourse * 4
+			: creditsPerCourse * 1
+	const currentCredits = countCredits(courses || [])
 
 	const infoBar = []
 	if (schedule && courses && courses.length) {
-		const courseCount = courses.length
+		let courseCount = courses.length
 
 		infoBar.push(
 			<InfoItem key="course-count">
@@ -161,8 +165,8 @@ function Semester(props) {
 			{schedule ? (
 				<CourseList
 					courses={courses || []}
-					creditCount={currentCredits}
-					availableCredits={recommendedCredits}
+					usedSlots={currentCredits / creditsPerCourse}
+					maxSlots={recommendedCredits / creditsPerCourse}
 					studentId={studentId}
 					schedule={schedule}
 					conflicts={conflicts || []}

--- a/modules/gob-web/modules/course-table/semester.js
+++ b/modules/gob-web/modules/course-table/semester.js
@@ -107,10 +107,8 @@ function Semester(props) {
 
 	// `recommendedCredits` is 4 for fall/spring and 1 for everything else
 	const creditsPerCourse = 1
-	const recommendedCredits =
-		semester === 1 || semester === 3
-			? creditsPerCourse * 4
-			: creditsPerCourse * 1
+	let recommendedCredits = semester === 1 || semester === 3 ? 4 : 1
+	let recommendedSlots = creditsPerCourse * recommendedCredits
 	const currentCredits = countCredits(courses || [])
 
 	const infoBar = []
@@ -166,7 +164,7 @@ function Semester(props) {
 				<CourseList
 					courses={courses || []}
 					usedSlots={currentCredits / creditsPerCourse}
-					maxSlots={recommendedCredits / creditsPerCourse}
+					maxSlots={recommendedSlots / creditsPerCourse}
 					studentId={studentId}
 					schedule={schedule}
 					conflicts={conflicts || []}

--- a/modules/gob-web/modules/course/expanded.js
+++ b/modules/gob-web/modules/course/expanded.js
@@ -18,6 +18,7 @@ const Heading = styled.h2`
 
 const Description = styled.div`
 	hyphens: auto;
+	margin-bottom: 1em;
 `
 
 const Column = styled.div`

--- a/modules/gob-web/modules/student/area-picker.js
+++ b/modules/gob-web/modules/student/area-picker.js
@@ -144,16 +144,17 @@ export default class AreaPickerContainer extends React.PureComponent<
 		filter: '',
 	}
 
+	updateQuery = (ev: SyntheticInputEvent<HTMLInputElement>) => {
+		let filter = (ev.target.value || '').toLowerCase()
+		this.setState(() => ({filter}))
+	}
+
 	render() {
 		return (
 			<AreaPicker
 				{...this.props}
 				filterText={this.state.filter}
-				onFilterChange={ev =>
-					this.setState(() => ({
-						filter: (ev.target.value || '').toLowerCase(),
-					}))
-				}
+				onFilterChange={this.updateQuery}
 			/>
 		)
 	}

--- a/modules/gob-worker-load-data/source/clean-prior-data.js
+++ b/modules/gob-worker-load-data/source/clean-prior-data.js
@@ -4,7 +4,6 @@ import {db} from './db'
 import range from 'idb-range'
 import fromPairs from 'lodash/fromPairs'
 import map from 'lodash/map'
-import series from 'p-series'
 import debug from 'debug'
 import getCacheStoreName from './get-cache-store-name'
 import type {InfoFileTypeEnum} from './types'
@@ -45,8 +44,6 @@ export default async function cleanPriorData(
 		)
 	}
 
-	return series([
-		() => db.store(type).batch(operations),
-		() => db.store(getCacheStoreName(type)).del(path),
-	])
+	await db.store(type).batch(operations)
+	await db.store(getCacheStoreName(type)).del(path)
 }

--- a/modules/gob-worker-load-data/source/lib-prepare-course.js
+++ b/modules/gob-worker-load-data/source/lib-prepare-course.js
@@ -6,24 +6,20 @@ import {splitParagraph} from '@gob/lib'
 import {convertTimeStringsToOfferings} from 'sto-sis-time-parser'
 
 export default function prepareCourse(course: any) {
-	const nameWords = splitParagraph(course.name)
-	const notesWords = splitParagraph((course.notes || []).join('\n'))
-	const titleWords = splitParagraph(course.title)
-	const descWords = splitParagraph((course.description || []).join('\n'))
+	const profWords = new Set(flatMap(course.instructors, splitParagraph))
+	const allWords = new Set([
+		...splitParagraph(course.name),
+		...splitParagraph((course.notes || []).join('\n')),
+		...splitParagraph(course.title || ''),
+		...splitParagraph((course.description || []).join('\n')),
+	])
 
 	return {
 		name: course.name || course.title,
 		dept: course.dept || buildDeptString(course.departments),
 		deptnum: course.deptnum || buildDeptNum(course),
 		offerings: course.offerings || convertTimeStringsToOfferings(course),
-		words: [
-			...new Set([
-				...nameWords,
-				...notesWords,
-				...titleWords,
-				...descWords,
-			]),
-		],
-		profWords: [...new Set(flatMap(course.instructors, splitParagraph))],
+		words: [...allWords],
+		profWords: [...profWords],
 	}
 }

--- a/modules/gob-worker-load-data/source/load-files.js
+++ b/modules/gob-worker-load-data/source/load-files.js
@@ -28,9 +28,7 @@ export default function loadFiles(url: string, baseUrl: string) {
 	log(url)
 
 	return fetchJson(url)
-		.then(data => {
-			return proceedWithUpdate(baseUrl, ((data: any): InfoIndexFile))
-		})
+		.then(data => proceedWithUpdate(baseUrl, ((data: any): InfoIndexFile)))
 		.catch(err => handleErrors(err, url))
 }
 

--- a/modules/gob-worker-load-data/source/update-database.js
+++ b/modules/gob-worker-load-data/source/update-database.js
@@ -1,6 +1,5 @@
 // @flow
 
-import series from 'p-series'
 import debug from 'debug'
 import {status, text} from '@gob/lib'
 
@@ -31,18 +30,18 @@ export default function updateDatabase(
 	// Append the hash, to act as a sort of cache-busting mechanism
 	const url = `${infoFileBase}/${path}?v=${hash}`
 
-	const nextStep = (rawData: string) => {
+	const nextStep = async (rawData: string) => {
 		// now parse the data into a usable form
 		const data = parseData(rawData, type)
 
-		return series([
-			// clear out any old data
-			() => cleanPriorData(path, type),
-			// store the new data
-			() => storeData(path, type, data),
-			// record that we stored the new data
-			() => cacheItemHash(path, type, hash),
-		])
+		// clear out any old data
+		await cleanPriorData(path, type)
+
+		// store the new data
+		await storeData(path, type, data)
+
+		// record that we stored the new data
+		await cacheItemHash(path, type, hash)
 	}
 
 	const onFailure = () => {


### PR DESCRIPTION
This is a bunch of stuff that I cleaned up during the Carleton port, and am now copying back to Gobbldygook-proper.

- Less lodash stuff (fewer uses of the functions, and also less lodash-specific shorthands)
- More ES6 – eg, Array/String#includes, and Map/Set
- When searching, split deptnum into a combined department/number/section query. This starts paving the way to remove the "deptnum" concept from our data layer.
- Added Flow to a few more modules
- Use more async functions
- Change `<CourseList/>` to use a concept of "empty slots" instead of just counting credits == courses (helps with Carleton/other schools, where a course is multiple credits)
- Added space after the course description in the modal view
- Fixed a crash when searching for an area