### PR TITLE
Remove margin:0 from AvatarLetter

### DIFF
--- a/modules/gob-web/components/avatar-letter.js
+++ b/modules/gob-web/components/avatar-letter.js
@@ -13,7 +13,6 @@ const Wrapper = styled.div`
 
 	display: inline-block;
 
-	margin: 0;
 	padding: 0;
 
 	${({size = '48px'}) => css`


### PR DESCRIPTION
I don't think it's needed, and it's causing #2226

Closes #2226 