### PR TITLE
Show newest modified student items at the top

### DIFF
--- a/modules/gob-web/modules/student-picker/student-list.js
+++ b/modules/gob-web/modules/student-picker/student-list.js
@@ -62,6 +62,10 @@ export default function StudentList(props: Props) {
 			/>
 		))
 
+	if (sortByKey === 'dateLastModified') {
+		filtered = filtered.reverse()
+	}
+
 	return (
 		<OuterCard>
 			<PlainList>{[...filtered]}</PlainList>


### PR DESCRIPTION
Currently the student items show the newest at the bottom when sorting by modified. This reverses that to show them at the top of the list. It feels more natural.