### PR TITLE
Add term to fabrication type

### DIFF
--- a/modules/gob-object-student/types.js
+++ b/modules/gob-object-student/types.js
@@ -21,6 +21,7 @@ export type FabricationType = {|
 	+number: number,
 	+section: string,
 	+semester: number,
+	+term: number,
 	+year: number,
 |}
 


### PR DESCRIPTION
Term is used in the fabrication listings, but it's not listed in the type.