### PR TITLE
Save students on undo/redo

### DIFF
--- a/modules/gob-web/helpers/save-student.js
+++ b/modules/gob-web/helpers/save-student.js
@@ -24,6 +24,8 @@ export function removeStudentFromCache(studentId: string) {
 }
 
 export async function saveStudent(student: Student) {
+	console.info(`saving ${student.id} (${student.name})`)
+
 	student = student.set('dateLastModified', new Date())
 	let str = stringify(student)
 	localStorage.setItem(student.id, str)

--- a/modules/gob-web/redux/index-development.js
+++ b/modules/gob-web/redux/index-development.js
@@ -3,6 +3,7 @@
 import {applyMiddleware, createStore, compose} from 'redux'
 import promiseMiddleware from 'redux-promise'
 import thunkMiddleware from 'redux-thunk'
+import saveStudentsMiddleware from './middleware/save-student'
 import {createLogger as loggingMiddleware} from 'redux-logger'
 import rootReducer from './reducer'
 
@@ -10,6 +11,7 @@ import rootReducer from './reducer'
 let middleware = [
 	promiseMiddleware,
 	thunkMiddleware,
+	saveStudentsMiddleware,
 ]
 
 if (!global.TESTING) {

--- a/modules/gob-web/redux/index-production.js
+++ b/modules/gob-web/redux/index-production.js
@@ -3,12 +3,14 @@
 import {applyMiddleware, createStore, compose} from 'redux'
 import promiseMiddleware from 'redux-promise'
 import thunkMiddleware from 'redux-thunk'
+import saveStudentsMiddleware from './middleware/save-student'
 import rootReducer from './reducer'
 
 // prettier-ignore
 let middleware = [
 	promiseMiddleware,
 	thunkMiddleware,
+	saveStudentsMiddleware,
 ]
 
 const finalCreateStore = compose(

--- a/modules/gob-web/redux/middleware/save-student.js
+++ b/modules/gob-web/redux/middleware/save-student.js
@@ -1,0 +1,59 @@
+import * as studentActions from '../students/constants'
+import {ActionTypes as UndoableActionTypes} from 'redux-undo'
+import {saveStudent} from '../../helpers/save-student'
+import values from 'lodash/values'
+
+const whitelist = new Set([
+	studentActions.INIT_STUDENT,
+	studentActions.IMPORT_STUDENT,
+	studentActions.CHANGE_STUDENT,
+	UndoableActionTypes.UNDO,
+	UndoableActionTypes.REDO,
+])
+
+export const shouldTakeAction = ({type}) => {
+	return whitelist.has(type)
+}
+
+const saveStudentsMiddleware = store => next => action => {
+	if (!shouldTakeAction(action)) {
+		return next(action)
+	}
+
+	console.log(action)
+
+	// save a copy of the old state
+	let oldState = store.getState()
+	let oldStudents = oldState.students
+
+	// dispatch the action along the chain
+	// this is what actually changes the state
+	let result = next(action)
+
+	// grab a copy of the *new* state
+	let newState = store.getState()
+	let newStudents = newState.students
+
+	if (oldStudents === newStudents) {
+		return result
+	}
+
+	let studentIds = values(newStudents).map(s => s.present.id)
+
+	// get any student whose identity has changed
+	let toSave = studentIds.filter(id => {
+		if (!oldStudents.hasOwnProperty(id)) {
+			return true
+		}
+		return newStudents[id].present !== oldStudents[id].present
+	})
+
+	// save them
+	let promises = toSave.map(id => {
+		return saveStudent(newStudents[id].present)
+	})
+
+	return Promise.all(promises).then(() => result)
+}
+
+export default saveStudentsMiddleware

--- a/modules/gob-web/redux/students/actions/change.js
+++ b/modules/gob-web/redux/students/actions/change.js
@@ -1,17 +1,15 @@
 // @flow
 
 import {Student} from '@gob/object-student'
-import {saveStudent} from '../../../helpers/save-student'
 
 export const CHANGE_STUDENT: 'gobbldygook/students/CHANGE_STUDENT' =
 	'gobbldygook/students/CHANGE_STUDENT'
 
 type Action = {type: typeof CHANGE_STUDENT, payload: Student}
 
-export type ActionCreator = Student => Action | Promise<Action>
+export type ActionCreator = Student => Action
 
-export const action: ActionCreator = async (s: Student) => {
-	s = await saveStudent(s)
+export const action: ActionCreator = (s: Student) => {
 	return {type: CHANGE_STUDENT, payload: s}
 }
 

--- a/modules/gob-web/redux/students/constants.js
+++ b/modules/gob-web/redux/students/constants.js
@@ -15,3 +15,5 @@ export const SAVE_STUDENT: 'gobbldygook/processed/SAVE_STUDENT' =
 
 export const INIT_STUDENT: 'gobbldygook/processed/INIT_STUDENT' =
 	'gobbldygook/processed/INIT_STUDENT'
+
+export {CHANGE_STUDENT} from './actions/change'


### PR DESCRIPTION
Restores the save-students middleware and removes the requirement for having change-student save during the execution of the action.

Closes #2285 