### PR TITLE
Make the loading component look good (with cards)

### DIFF
--- a/modules/gob-web/components/loading-comp.js
+++ b/modules/gob-web/components/loading-comp.js
@@ -1,6 +1,15 @@
 // @flow
 
 import React from 'react'
+import {Card} from './card'
+import {RaisedButton} from './button'
+import styled from 'styled-components'
+
+let CenteredCard = styled(Card)`
+	margin: 3rem auto 1rem;
+	max-width: 30em;
+	padding: 2rem;
+`
 
 export function LoadingComponent(props: {
 	error: ?Error,
@@ -10,22 +19,28 @@ export function LoadingComponent(props: {
 }) {
 	if (props.error) {
 		return (
-			<p>
-				Error! <button onClick={props.retry}>Retry</button>
-			</p>
+			<Card>
+				<p>Error!</p>
+				<RaisedButton onClick={props.retry}>Retry</RaisedButton>
+			</Card>
 		)
 	}
 
 	if (props.timedOut) {
 		return (
-			<p>
-				Taking a long time… <button onClick={props.retry}>Retry</button>
-			</p>
+			<Card>
+				<p>Taking a long time…</p>
+				<RaisedButton onClick={props.retry}>Retry</RaisedButton>
+			</Card>
 		)
 	}
 
 	if (props.pastDelay) {
-		return <p>Loading…</p>
+		return (
+			<Card>
+				<p>Loading…</p>
+			</Card>
+		)
 	}
 
 	return null


### PR DESCRIPTION
I don't have a screenshot because I've been working off the glimpses I get of the loading component during the initial load.

But it used to just be black text on the gray background; now it's a card on the gray background.