### PR TITLE
Condense course offerings in modal

### DIFF
--- a/modules/gob-web/modules/course/expanded.js
+++ b/modules/gob-web/modules/course/expanded.js
@@ -6,7 +6,7 @@ import oxford from 'listify'
 import {BulletedList, ListItem} from '../../components/list'
 import CourseTitle from './course-title'
 import {semesterName, buildDeptNum} from '@gob/school-st-olaf-college'
-import {to12HourTime} from '@gob/lib'
+import {consolidateExpandedOfferings} from './offerings'
 import type {Course} from '@gob/types'
 
 const Heading = styled.h2`
@@ -94,23 +94,11 @@ export default class ExpandedCourse extends React.PureComponent<Props> {
 								: 'Offerings'}
 						</Heading>
 						<BulletedList>
-							{course.offerings.map(
-								({day, start, end, location}) => {
-									return (
-										<ListItem
-											key={`${day}-${start}-${end}`}
-										>
-											{day}
-											{' from '}
-											{to12HourTime(start)}
-											{' to '}
-											{to12HourTime(end)}
-											{', in '}
-											{location}
-										</ListItem>
-									)
-								},
-							)}
+							{consolidateExpandedOfferings(
+								course.offerings || [],
+							).map(offering => (
+								<ListItem key={offering}>{offering}</ListItem>
+							))}
 						</BulletedList>
 					</div>
 				)}

--- a/modules/gob-web/modules/course/offerings.js
+++ b/modules/gob-web/modules/course/offerings.js
@@ -12,6 +12,8 @@ const DAYS = Map({
 	Fr: 'F',
 })
 
+const nbsp = '\u00a0'
+
 export function consolidateOfferings(
 	offerings: Array<Offering>,
 ): Array<?string> {
@@ -43,12 +45,16 @@ export function consolidateExpandedOfferings(
 
 			let days = groupedOffers.map(({day}) => DAYS.get(day)).join('/')
 			let {start, end, location} = groupedOffers.first()
-			let nbsp = '\u00a0'
-			location = location.replace(/ /g, nbsp)
 
-			return `${days} from ${to12HourTime(start)} to ${to12HourTime(
-				end,
-			)}, in${nbsp}${location}`
+			start = to12HourTime(start)
+			end = to12HourTime(end)
+
+			if (location) {
+				location = location.replace(/ /g, nbsp)
+				return `${days} from ${start} to ${end}, in${nbsp}${location}`
+			}
+
+			return `${days} from ${start} to ${end}`
 		})
 		.toList()
 		.toArray()

--- a/modules/gob-web/modules/course/offerings.js
+++ b/modules/gob-web/modules/course/offerings.js
@@ -30,3 +30,26 @@ export function consolidateOfferings(
 		.toList()
 		.toArray()
 }
+
+export function consolidateExpandedOfferings(
+	offerings: Array<Offering>,
+): Array<?string> {
+	return List(offerings)
+		.groupBy(({start, end}) => `${start} ${end}`)
+		.map(groupedOffers => {
+			if (groupedOffers.size < 1) {
+				return null
+			}
+
+			let days = groupedOffers.map(({day}) => DAYS.get(day)).join('/')
+			let {start, end, location} = groupedOffers.first()
+			let nbsp = '\u00a0'
+			location = location.replace(/ /g, nbsp)
+
+			return `${days} from ${to12HourTime(start)} to ${to12HourTime(
+				end,
+			)}, in${nbsp}${location}`
+		})
+		.toList()
+		.toArray()
+}


### PR DESCRIPTION
* Condenses offerings into condensed repeated schedules
* Separates day names with slashes
* Adds non-breaking spaces between location strings to keep them on the same line

<img width="731" alt="single" src="https://user-images.githubusercontent.com/5240843/46690719-482f0300-cbc0-11e8-873f-4727ae1d76ed.png">
<img width="731" alt="combined" src="https://user-images.githubusercontent.com/5240843/46690720-482f0300-cbc0-11e8-8a96-b0d1055ef4e4.png">
<img width="731" alt="interim" src="https://user-images.githubusercontent.com/5240843/46690721-482f0300-cbc0-11e8-80cb-4e1c6943cc82.png">