### PR TITLE
Area tweaks

### DIFF
--- a/modules/gob-web/modules/area-of-study/area-of-study.js
+++ b/modules/gob-web/modules/area-of-study/area-of-study.js
@@ -4,7 +4,7 @@ import React from 'react'
 import cx from 'classnames'
 import {FlatButton} from '../../components/button'
 import {Icon} from '../../components/icon'
-import Requirement from './requirement'
+import {TopLevelRequirement} from './requirement'
 import ProgressBar from '../../components/progress-bar'
 import {close, chevronUp, chevronDown} from '../../icons/ionicons'
 import {type EvaluationResult} from '@gob/examine-student'
@@ -123,9 +123,8 @@ export class AreaOfStudy extends React.Component<Props> {
 				) : null}
 
 				{isOpen ? (
-					<Requirement
+					<TopLevelRequirement
 						info={(results: any)}
-						topLevel
 						onAddOverride={onAddOverride}
 						onRemoveOverride={onRemoveOverride}
 						onToggleOverride={onToggleOverride}

--- a/modules/gob-web/modules/area-of-study/area-of-study.scss
+++ b/modules/gob-web/modules/area-of-study/area-of-study.scss
@@ -115,7 +115,8 @@
 	height: 4px;
 	margin: 0 auto;
 
-	.area--summary:focus &, .area--summary:active & {
+	.area--summary:focus &,
+	.area--summary:active & {
 		box-shadow: 0 0 0 2px white;
 	}
 

--- a/modules/gob-web/modules/area-of-study/area-of-study.scss
+++ b/modules/gob-web/modules/area-of-study/area-of-study.scss
@@ -16,6 +16,11 @@
 	--requirement-primary-color: var(--gray-300);
 	--requirement-text-color: var(--text-color);
 	--requirement-accent-color: var(--text-color);
+
+	& > .children > .requirement {
+		margin-left: 0.75em;
+		margin-right: 0.75em;
+	}
 }
 
 .area .message {

--- a/modules/gob-web/modules/area-of-study/area-of-study.scss
+++ b/modules/gob-web/modules/area-of-study/area-of-study.scss
@@ -4,14 +4,18 @@
 	font-size: 0.85em;
 
 	&.errored {
-		background-color: $red-50;
-		color: $red-900;
+		background-color: var(--red-50);
+		color: var(--red-900);
 	}
 
 	&:not(.errored).loading {
 		opacity: 0.75;
 		color: gray;
 	}
+
+	--requirement-primary-color: var(--gray-300);
+	--requirement-text-color: var(--text-color);
+	--requirement-accent-color: var(--text-color);
 }
 
 .area .message {
@@ -83,7 +87,7 @@
 		text-decoration: none;
 	}
 
-	@nest .area[open] & a {
+	.area[open] & a {
 		text-decoration: underline;
 	}
 }
@@ -106,7 +110,7 @@
 	height: 4px;
 	margin: 0 auto;
 
-	@nest .area--summary:focus &, .area--summary:active & {
+	.area--summary:focus &, .area--summary:active & {
 		box-shadow: 0 0 0 2px white;
 	}
 

--- a/modules/gob-web/modules/area-of-study/expression.js
+++ b/modules/gob-web/modules/area-of-study/expression.js
@@ -61,9 +61,14 @@ function makeOfExpression({expr, ctx}) {
 				expr.$count.$operator,
 		  )} ${expr.$count.$num} from among`
 
-	const contents = expr.$of.map((ex, i) => (
+	let contents = expr.$of.map((ex, i) => (
 		<Expression key={i} expr={ex} ctx={ctx} />
 	))
+
+	let allAreReferences = expr.$of.every(expr => expr.$type === 'reference')
+	if (allAreReferences) {
+		contents = []
+	}
 
 	return {description, contents}
 }

--- a/modules/gob-web/modules/area-of-study/expression.scss
+++ b/modules/gob-web/modules/area-of-study/expression.scss
@@ -41,7 +41,7 @@
 }
 
 .expression--course.not-used {
-	opacity: 0.5;
+	// opacity: 0.5;
 }
 
 .expression .joiner {

--- a/modules/gob-web/modules/area-of-study/expression.scss
+++ b/modules/gob-web/modules/area-of-study/expression.scss
@@ -110,9 +110,9 @@
 		border: solid 1px var(--green-100);
 	}
 	&.not-used {
-		background-color: var(--pink-50);
+		background-color: var(--gray-100);
 		color: var(--text-color);
-		border: solid 1px var(--pink-100);
+		border: solid 1px var(--gray-400);
 	}
 }
 

--- a/modules/gob-web/modules/area-of-study/requirement.js
+++ b/modules/gob-web/modules/area-of-study/requirement.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Component} from 'react'
-
+import cx from 'classnames'
 import {isRequirementName} from '@gob/examine-student'
 
 import {Icon} from '../../components/icon'
@@ -38,35 +38,34 @@ type RequirementProps = Props & {
 }
 
 function Requirement(props: RequirementProps) {
-	const {topLevel = false} = props
 	let info = props.info || {}
 
-	const childKeys = Object.keys(info).filter(isRequirementName)
+	let childKeys = Object.keys(info).filter(isRequirementName)
 
-	const wasEvaluated = info.result && info.result._checked
-	const computationClassName = wasEvaluated
+	let wasEvaluated = info.result && info.result._checked
+	let computationClassName = wasEvaluated
 		? info.computed
 			? 'result-success'
 			: 'result-failure'
 		: ''
-	const status = <ResultIndicator result={info.computed} />
+	let status = <ResultIndicator result={info.computed} />
 
-	const extraClasses = [info.overridden ? 'overridden' : '']
+	let extraClasses = [info.overridden ? 'overridden' : '']
 
-	const result = info.result && (
+	let result = info.result && (
 		<div className="result">
 			<Expression expr={info.result} ctx={info} />
 		</div>
 	)
 
-	const message = info.message && <p className="message">{info.message}</p>
-	const description = info.description && (
+	let message = info.message && <p className="message">{info.message}</p>
+	let description = info.description && (
 		<p className="description">{info.description}</p>
 	)
 
-	const filterEl = info.filter && <Filter expr={info.filter} ctx={info} />
+	let filterEl = info.filter && <Filter expr={info.filter} ctx={info} />
 
-	const title = !topLevel && (
+	let title = (
 		<h2 className="heading" title={props.name} onClick={props.onToggleOpen}>
 			<span className="title">
 				{' '}
@@ -89,7 +88,7 @@ function Requirement(props: RequirementProps) {
 		</h2>
 	)
 
-	const children = childKeys.map(key => (
+	let children = childKeys.map(key => (
 		<ExpandableRequirement
 			key={key}
 			name={key}
@@ -101,7 +100,7 @@ function Requirement(props: RequirementProps) {
 		/>
 	))
 
-	const overrideButtons = info.message &&
+	let overrideButtons = info.message &&
 		!info.result && (
 			<span className="required-override-buttons button-group">
 				<FlatButton
@@ -115,12 +114,12 @@ function Requirement(props: RequirementProps) {
 			</span>
 		)
 
-	let className = [
+	let className = cx(
 		'requirement',
-		extraClasses.join(' '),
+		...extraClasses,
 		computationClassName,
 		props.isOpen ? 'is-open' : 'is-closed',
-	].join(' ')
+	)
 
 	return (
 		<div className={className}>
@@ -143,7 +142,7 @@ type State = {
 
 export default class ExpandableRequirement extends Component<Props, State> {
 	state = {
-		open: true,
+		open: false,
 	}
 
 	handleToggleOpen = () => {
@@ -159,4 +158,32 @@ export default class ExpandableRequirement extends Component<Props, State> {
 			/>
 		)
 	}
+}
+
+export function TopLevelRequirement(props: Props) {
+	let info = props.info || {}
+	let childKeys = Object.keys(info).filter(isRequirementName)
+	let children = childKeys.map(key => (
+		<ExpandableRequirement
+			key={key}
+			name={key}
+			info={((info[key]: any): RequirementInfo)}
+			path={props.path.concat(key)}
+			onAddOverride={props.onAddOverride}
+			onToggleOverride={props.onToggleOverride}
+			onRemoveOverride={props.onRemoveOverride}
+		/>
+	))
+
+	return (
+		<>
+			{info.filter && <Filter expr={info.filter} ctx={info} />}
+			{info.result && (
+				<div className="result">
+					<Expression expr={info.result} ctx={info} />
+				</div>
+			)}
+			{children.length && <div className="children">{children}</div>}
+		</>
+	)
 }

--- a/modules/gob-web/modules/area-of-study/requirement.js
+++ b/modules/gob-web/modules/area-of-study/requirement.js
@@ -68,9 +68,8 @@ function Requirement(props: RequirementProps) {
 	let title = (
 		<h2 className="heading" title={props.name} onClick={props.onToggleOpen}>
 			<span className="title">
-				{' '}
-				{props.name}
 				<span className="status">{status}</span>
+				{props.name}
 			</span>
 			<span className="manual-override">
 				<span className="overridden-msg">

--- a/modules/gob-web/modules/area-of-study/requirement.scss
+++ b/modules/gob-web/modules/area-of-study/requirement.scss
@@ -51,8 +51,8 @@
 }
 
 .result > .expression {
-		display: block;
-	}
+	display: block;
+}
 
 .requirement .requirement .result,
 .requirement .requirement .message,
@@ -100,7 +100,6 @@
 .requirement.result-failure {
 	--requirement-primary-color: var(--gray-300);
 }
-
 
 .requirement .requirement .heading {
 	font-size: 0.9em;

--- a/modules/gob-web/modules/area-of-study/requirement.scss
+++ b/modules/gob-web/modules/area-of-study/requirement.scss
@@ -3,7 +3,6 @@
 @import './variables-expression.scss';
 
 .requirement {
-	margin: 0.25em;
 	box-sizing: border-box;
 	font-variant-numeric: oldstyle-nums;
 
@@ -11,15 +10,7 @@
 	border: 0.5em solid var(--requirement-primary-color);
 	color: var(--requirement-text-color);
 
-	margin-left: 0.75em;
-
-	&:last-child {
-		margin-bottom: 0.5em;
-	}
-
-	& + & {
-		margin-top: 0.75em;
-	}
+	margin: 0.25em 0.5em 0.75em;
 
 	&.is-closed > *:not(.heading) {
 		display: none;

--- a/modules/gob-web/modules/area-of-study/requirement.scss
+++ b/modules/gob-web/modules/area-of-study/requirement.scss
@@ -6,100 +6,110 @@
 	margin: 0.25em;
 	box-sizing: border-box;
 	font-variant-numeric: oldstyle-nums;
-}
 
-.requirement.is-closed > *:not(.heading) {
-	display: none;
-}
-
-.requirement .requirement {
-	margin-left: 0.5em;
-}
-
-.requirement + .requirement {
-	margin-top: 0.75em;
-}
-
-.requirement:last-child {
-	margin-bottom: 0.5em;
-}
-
-.requirement .requirement {
-	border: 1px solid #e9ebeb;
 	border-radius: 4px;
+	border: 0.5em solid var(--requirement-primary-color);
+	color: var(--requirement-text-color);
+
+	margin-left: 0.75em;
+
+	&:last-child {
+		margin-bottom: 0.5em;
+	}
+
+	& + & {
+		margin-top: 0.75em;
+	}
+
+	&.is-closed > *:not(.heading) {
+		display: none;
+	}
+	&.is-open {
+		margin-bottom: 1em;
+	}
+
+	&.is-open > .heading {
+		padding-bottom: 0.7em;
+	}
+
+	.override-button {
+		padding: 0.25em 0.5em;
+		margin-right: 0.25em;
+		color: $gray-500;
+	}
+
+	.result {
+		padding-left: 0.25em;
+		padding-right: 0.25em;
+
+		display: flex;
+		justify-content: center;
+	}
+
+	.status {
+		margin-right: 0.5em;
+
+		.result-indicator {
+			margin-right: 0;
+		}
+	}
+
+	&.result-success > .heading .status {
+		color: $result-success-color;
+	}
 }
 
-.override-button {
-	padding: 0.25em 0.5em;
-	margin-right: 0.25em;
-	color: $gray-500;
-}
+.result > .expression {
+		display: block;
+	}
 
-.result {
-	padding-left: 0.25em;
-	padding-right: 0.25em;
-
-	display: flex;
-	justify-content: center;
-}
-
-.requirement .requirement .requirement .result,
-.requirement .requirement .requirement .message,
-.requirement .requirement .requirement .description,
-.requirement .requirement .requirement .filter {
+.requirement .requirement .result,
+.requirement .requirement .message,
+.requirement .requirement .description,
+.requirement .requirement .filter {
 	padding-left: $area-edge-padding;
 }
 
-.heading {
+.requirement .heading {
+	margin: 0;
 	font-size: 1em;
 	font-weight: 500;
 
-	border-bottom: $material-divider;
 	padding: 0.2em 0.15em 0.2em 0.25em;
 
 	display: flex;
 	flex-flow: row nowrap;
 	align-items: center;
 	justify-content: space-between;
+
+	background-color: var(--requirement-primary-color);
+
+	cursor: pointer;
 }
 
-.title {
+.requirement .title {
 	flex: 1;
-	padding: 0.45em 0.25em;
-}
-
-.heading .manual-override {
+	padding: 0;
 }
 
 .heading .manual-override button {
-	padding-left: 0.25em;
-	padding-right: 0.25em;
+	padding: 0 0.25em;
 }
 
-.title,
 .override-text {
 	padding: 0.45em 0.25em;
-}
-
-.override-text {
 	margin-left: 0.35em;
 	font-weight: normal;
 }
 
-.requirement.result-success > .heading {
-	background-color: $result-success-background;
+.requirement.result-success {
+	--requirement-primary-color: #{$result-success-background};
 }
 
-.status {
-	margin-left: 0.5em;
+.requirement.result-failure {
+	--requirement-primary-color: var(--gray-300);
+}
 
-	.result-indicator {
-		margin-left: 0;
-	}
-}
-.result-success > .heading .status {
-	color: $result-success-color;
-}
 
 .requirement .requirement .heading {
 	font-size: 0.9em;


### PR DESCRIPTION
Before | After
--- | ---
![screen shot 2018-10-09 at 4 43 27 pm](https://user-images.githubusercontent.com/464441/46700523-a7057400-cbe2-11e8-80c6-ecb0ccfa77e6.png) | ![screen shot 2018-10-09 at 4 44 01 pm](https://user-images.githubusercontent.com/464441/46700520-a4a31a00-cbe2-11e8-8b6a-ae412ef49f9e.png)

Overall, I like the new look - they are bigger hit targets; the bolder borders make it easier to visually parse the requirements; and hiding the duplicate listing of requirement references really helps.

Also, areas now start collapsed, to help avoid information overload. You can still expand them, but now it's more exploratory.