### PR TITLE
Implement "filter by" and "limit to" search fields in the sidebar

### DIFF
--- a/modules/gob-web/modules/course-searcher/lib.js
+++ b/modules/gob-web/modules/course-searcher/lib.js
@@ -147,7 +147,9 @@ export function sortAndGroup(
 
 	if (filtering) {
 		finalResults = nestedResults.get(filtering, List())
-		finalResults = finalResults.unshift(filtering)
+		if (finalResults.size) {
+			finalResults = finalResults.unshift(filtering)
+		}
 	} else {
 		finalResults = nestedResults
 			.map((val, key) => [key, val])

--- a/modules/gob-web/modules/course-searcher/lib.js
+++ b/modules/gob-web/modules/course-searcher/lib.js
@@ -82,8 +82,13 @@ const REVERSE_ORDER: Set<GROUP_BY_KEY> = Set.of('year', 'term', 'semester')
 
 export function sortAndGroup(
 	results: List<CourseType>,
-	args: {sorting: SORT_BY_KEY, grouping: GROUP_BY_KEY},
-): Array<string | CourseType> {
+	args: {
+		sorting: SORT_BY_KEY,
+		grouping: GROUP_BY_KEY,
+		filtering: string,
+		limiting: string,
+	},
+): List<string | CourseType> {
 	let {sorting, grouping} = args
 	console.time('query: grouping/sorting')
 
@@ -112,9 +117,7 @@ export function sortAndGroup(
 	nestedResults = nestedResults
 		.map((val, key) => [key, val])
 		.toList()
-		.toJS()
-
-	nestedResults = flatten((flatten(nestedResults): any))
+		.flatMap(([k, v]) => [k, ...v])
 
 	console.timeEnd('query: grouping/sorting')
 

--- a/modules/gob-web/modules/course-searcher/querent.js
+++ b/modules/gob-web/modules/course-searcher/querent.js
@@ -16,7 +16,7 @@ type Props = {
 		error: ?string,
 		inProgress: boolean,
 		didSearch: boolean,
-		results: Array<string | CourseType>,
+		results: List<string | CourseType>,
 	}) => React.Node,
 	groupBy: GROUP_BY_KEY,
 	sortBy: SORT_BY_KEY,

--- a/modules/gob-web/modules/course-searcher/querent.js
+++ b/modules/gob-web/modules/course-searcher/querent.js
@@ -6,7 +6,7 @@ import {queryCourseDatabase} from '../../helpers/query-course-database'
 import mem from 'mem'
 import {sortAndGroup} from './lib'
 import {ga} from '../../analytics'
-import {List} from 'immutable'
+import {List, Set} from 'immutable'
 import type {GROUP_BY_KEY, SORT_BY_KEY} from './constants'
 
 type Props = {
@@ -17,9 +17,13 @@ type Props = {
 		inProgress: boolean,
 		didSearch: boolean,
 		results: List<string | CourseType>,
+		keys: Array<string>,
+		years: Set<number>,
 	}) => React.Node,
 	groupBy: GROUP_BY_KEY,
 	sortBy: SORT_BY_KEY,
+	limitTo: string,
+	filterBy: string,
 }
 
 type State = {|
@@ -106,14 +110,28 @@ export class Querent extends React.Component<Props, State> {
 
 	render() {
 		let {error, inProgress, results, didSearch} = this.state
-		let {sortBy: sorting, groupBy: grouping} = this.props
-		let grouped = memSortAndGroup(results, {sorting, grouping})
+
+		let {
+			sortBy: sorting,
+			groupBy: grouping,
+			filterBy: filtering,
+			limitTo: limiting,
+		} = this.props
+
+		let {results: grouped, years, keys} = memSortAndGroup(results, {
+			sorting,
+			grouping,
+			filtering,
+			limiting,
+		})
 
 		return this.props.children({
 			error,
 			inProgress,
 			didSearch,
 			results: grouped,
+			years,
+			keys,
 		})
 	}
 }

--- a/modules/gob-web/modules/course-searcher/results-list.js
+++ b/modules/gob-web/modules/course-searcher/results-list.js
@@ -6,25 +6,9 @@ import {List} from 'immutable'
 import {Card} from '../../components/card'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import {DraggableCourse} from '../course'
-import {
-	toPrettyTerm,
-	expandYear,
-	semesterName,
-} from '@gob/school-st-olaf-college'
 import styled from 'styled-components'
 import {type Course as CourseType} from '@gob/types'
 import type {GROUP_BY_KEY} from './constants'
-
-const GROUP_BY_TO_TITLE: {[key: GROUP_BY_KEY]: (string) => string} = {
-	day: days => days,
-	department: depts => depts,
-	gened: gereqs => gereqs,
-	semester: sem => semesterName(sem),
-	term: term => toPrettyTerm(term),
-	time: times => times,
-	year: year => expandYear(year),
-	none: () => '',
-}
 
 type Results = List<string | CourseType>
 
@@ -119,12 +103,11 @@ export class CourseResultsList extends React.Component<Props> {
 		return getRowHeight(item)
 	}
 
-	renderHeader = (groupTitle: string, {style}: {style: Object}) => {
-		if (!groupTitle) {
+	renderHeader = (title: string, {style}: {style: Object}) => {
+		if (!title) {
 			return null
 		}
 
-		const title = GROUP_BY_TO_TITLE[this.props.groupedBy](groupTitle)
 		return (
 			<CourseGroupTitle style={style} title={title}>
 				<span>{title}</span>

--- a/modules/gob-web/modules/course-searcher/results-list.js
+++ b/modules/gob-web/modules/course-searcher/results-list.js
@@ -1,7 +1,8 @@
 // @flow
 
 import * as React from 'react'
-import {VariableSizeList as List} from 'react-window'
+import {VariableSizeList} from 'react-window'
+import {List} from 'immutable'
 import {Card} from '../../components/card'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import {DraggableCourse} from '../course'
@@ -25,7 +26,7 @@ const GROUP_BY_TO_TITLE: {[key: GROUP_BY_KEY]: (string) => string} = {
 	none: () => '',
 }
 
-type Results = Array<string | CourseType>
+type Results = List<string | CourseType>
 
 type Props = {
 	groupedBy: GROUP_BY_KEY,
@@ -33,7 +34,7 @@ type Props = {
 	studentId?: string,
 }
 
-const TermList = styled(List)`
+const TermList = styled(VariableSizeList)`
 	margin: 0;
 	padding: 0;
 	list-style: none;
@@ -109,7 +110,7 @@ function getRowHeight(item: string | CourseType) {
 
 export class CourseResultsList extends React.Component<Props> {
 	getRowHeight = (index: number) => {
-		let item = this.props.results[index]
+		let item = this.props.results.get(index)
 
 		if (!item) {
 			return null
@@ -133,7 +134,7 @@ export class CourseResultsList extends React.Component<Props> {
 
 	renderRow = (args: {index: number, style: Object}) => {
 		let {index, style} = args
-		let item = this.props.results[index]
+		let item = this.props.results.get(index)
 
 		if (!item) {
 			return null
@@ -155,7 +156,7 @@ export class CourseResultsList extends React.Component<Props> {
 					{({height, width}) => (
 						<TermList
 							height={height}
-							itemCount={this.props.results.length}
+							itemCount={this.props.results.size}
 							itemSize={this.getRowHeight}
 							width={width}
 						>

--- a/modules/gob-web/modules/course-searcher/results-list.js
+++ b/modules/gob-web/modules/course-searcher/results-list.js
@@ -65,7 +65,7 @@ const CourseListItem = styled(DraggableCourse)`
 function getRowHeight(item: string | CourseType) {
 	if (typeof item === 'string') {
 		// heading
-		return 45
+		return 65
 	}
 
 	let firstRowHeight = 20

--- a/modules/gob-web/modules/course-searcher/searcher.js
+++ b/modules/gob-web/modules/course-searcher/searcher.js
@@ -133,7 +133,7 @@ export class CourseSearcher extends React.Component<Props, State> {
 							)
 						}
 
-						if (results.length === 0) {
+						if (results.size === 0) {
 							if (!didSearch) {
 								return (
 									<Card className="course-results--notice">

--- a/modules/gob-web/modules/course-searcher/searcher.js
+++ b/modules/gob-web/modules/course-searcher/searcher.js
@@ -50,7 +50,7 @@ export class CourseSearcher extends React.Component<Props, State> {
 
 	handleGroupByChange = (ev: SyntheticEvent<HTMLSelectElement>) => {
 		let value: string = ev.currentTarget.value
-		this.setState(() => ({groupBy: (value: any)}))
+		this.setState(() => ({groupBy: (value: any), filterBy: ''}))
 	}
 
 	handleFilterByChange = (ev: SyntheticEvent<HTMLSelectElement>) => {

--- a/modules/gob-web/modules/course-searcher/searcher.js
+++ b/modules/gob-web/modules/course-searcher/searcher.js
@@ -140,6 +140,13 @@ export class CourseSearcher extends React.Component<Props, State> {
 						let filters = (
 							<Card className="search-filters">
 								<LabelledSelect
+									label="Limit to:"
+									options={potentialYearLimits}
+									onChange={this.handleLimitToChange}
+									value={limitTo}
+								/>
+
+								<LabelledSelect
 									label="Sort by:"
 									options={toPairs(SORT_BY)}
 									onChange={this.handleSortChange}
@@ -158,13 +165,6 @@ export class CourseSearcher extends React.Component<Props, State> {
 									options={potentialFilters}
 									onChange={this.handleFilterByChange}
 									value={filterBy}
-								/>
-
-								<LabelledSelect
-									label="Limit to:"
-									options={potentialYearLimits}
-									onChange={this.handleLimitToChange}
-									value={limitTo}
 								/>
 							</Card>
 						)

--- a/modules/gob-web/modules/course-searcher/searcher.js
+++ b/modules/gob-web/modules/course-searcher/searcher.js
@@ -137,6 +137,13 @@ export class CourseSearcher extends React.Component<Props, State> {
 							.toArray()
 						potentialYearLimits.unshift(['', 'All Years'])
 
+						if (limitTo && !years.has(parseInt(limitTo, 10))) {
+							potentialYearLimits.push([
+								limitTo,
+								expandYear(limitTo),
+							])
+						}
+
 						let filters = (
 							<Card className="search-filters">
 								<LabelledSelect

--- a/modules/gob-web/modules/course-searcher/searcher.scss
+++ b/modules/gob-web/modules/course-searcher/searcher.scss
@@ -110,6 +110,7 @@
 
 .search-filters select {
 	font-size: 0.9em;
+	width: 100%;
 }
 
 .course-search--results_sizer {


### PR DESCRIPTION
"filter by" lets you filter down to just a specific group in the list, so if you group by term, you can only see that term; if you group by department, you can only see that department; etc. It's live with respect to your current "group by" option.

"limit to {year}" lets you easily limit the results to a specific year. It's applied first, so if you limit to 2012, you'll only see grouping options for 2012, etc.

<img width="280" src=https://user-images.githubusercontent.com/464441/46711087-6a507180-cc10-11e8-90a7-0eec825cf47e.png>

---

Known issues:

- [x] ~~If you pick a filter and then change the year limit to a year without that filter key, you will get no results. (this no longer sounds like an issue. testing needed.)~~ not actually the problem; see below
- [x] if you filter by something, then change the grouping, it still tries to filter by the old key, which no longer applies to the new groups. (fixed by resetting filterBy when we change groupBy)