### PR TITLE
Remove nested paragraphs from course description

### DIFF
--- a/modules/gob-web/modules/course/expanded.js
+++ b/modules/gob-web/modules/course/expanded.js
@@ -62,11 +62,9 @@ export default class ExpandedCourse extends React.PureComponent<Props> {
 				{course.description && (
 					<Description>
 						<Heading>Description</Heading>
-						<p>
-							{course.description.map((d, i) => (
-								<p key={i}>{d}</p>
-							))}
-						</p>
+						{course.description.map((d, i) => (
+							<p key={i}>{d}</p>
+						))}
 					</Description>
 				)}
 


### PR DESCRIPTION
Fixing something I introduced in #2300