### PR TITLE
Remove the remove-area buttons from the "edit area group" mode

### DIFF
--- a/modules/gob-web/modules/area-of-study/area-of-study.js
+++ b/modules/gob-web/modules/area-of-study/area-of-study.js
@@ -2,21 +2,17 @@
 
 import React from 'react'
 import cx from 'classnames'
-import {FlatButton} from '../../components/button'
 import {Icon} from '../../components/icon'
 import {TopLevelRequirement} from './requirement'
 import ProgressBar from '../../components/progress-bar'
-import {close, chevronUp, chevronDown} from '../../icons/ionicons'
+import {chevronUp, chevronDown} from '../../icons/ionicons'
 import {type EvaluationResult} from '@gob/examine-student'
 import {type AreaQuery} from '@gob/object-student'
 
 import './area-of-study.scss'
 
 type Props = {
-	showCloseButton?: boolean,
-	showEditButton?: boolean,
 	isOpen?: boolean,
-	showConfirmRemoval?: boolean,
 	style?: {},
 
 	areaOfStudy: AreaQuery,
@@ -24,28 +20,20 @@ type Props = {
 	examining?: boolean,
 	results: ?EvaluationResult,
 	onToggleOpen?: Event => mixed,
-	onRemove?: Event => mixed,
 	onAddOverride?: (Array<string>, Event) => mixed,
 	onRemoveOverride?: (Array<string>, Event) => mixed,
 	onToggleOverride?: (Array<string>, Event) => mixed,
-	onRemovalStart?: Event => mixed,
-	onRemovalCancel?: Event => mixed,
 }
 
 export class AreaOfStudy extends React.Component<Props> {
 	render() {
 		let {
 			isOpen = true,
-			showConfirmRemoval = false,
 			results,
 			error = null,
 			examining = false,
 			areaOfStudy,
 			onToggleOpen = () => {},
-			showCloseButton = false,
-			onRemovalStart = () => {},
-			onRemove = () => {},
-			onRemovalCancel = () => {},
 			onAddOverride = () => {},
 			onRemoveOverride = () => {},
 			onToggleOverride = () => {},
@@ -53,12 +41,6 @@ export class AreaOfStudy extends React.Component<Props> {
 		} = this.props
 
 		let {name = 'Unknown Area'} = areaOfStudy
-
-		// TODO: fix slugs
-		// let slug = ''
-		// if (this.state.results) {
-		// 	slug = this.state.results.slug
-		// }
 
 		let progressAt = 0
 		let progressOf = 1
@@ -81,14 +63,6 @@ export class AreaOfStudy extends React.Component<Props> {
 							<CatalogLink slug={'' /*slug*/} name={name} />
 						</h1>
 						<span className="icons">
-							{showCloseButton && (
-								<FlatButton
-									className="area--remove-button"
-									onClick={onRemovalStart}
-								>
-									<Icon>{close}</Icon>
-								</FlatButton>
-							)}
 							<Icon className="area--open-indicator">
 								{isOpen ? chevronUp : chevronDown}
 							</Icon>
@@ -103,14 +77,6 @@ export class AreaOfStudy extends React.Component<Props> {
 						max={progressOf}
 					/>
 				</div>
-
-				{showConfirmRemoval && (
-					<RemovalConfirmation
-						name={name}
-						onRemove={onRemove}
-						onCancel={onRemovalCancel}
-					/>
-				)}
 
 				{error && (
 					<p className="message area--error">
@@ -151,29 +117,5 @@ const CatalogLink = ({slug, name}: {slug: ?string, name: string}) => {
 		>
 			{name}
 		</a>
-	)
-}
-
-const RemovalConfirmation = (props: {
-	name: string,
-	onRemove: Event => mixed,
-	onCancel: Event => mixed,
-}) => {
-	let {name, onRemove, onCancel} = props
-	return (
-		<div className="area--confirm-removal">
-			<p>
-				Remove <strong>{name}</strong>?
-			</p>
-			<span className="button-group">
-				<FlatButton
-					className="area--actually-remove-area"
-					onClick={onRemove}
-				>
-					Remove
-				</FlatButton>
-				<FlatButton onClick={onCancel}>Cancel</FlatButton>
-			</span>
-		</div>
 	)
 }

--- a/modules/gob-web/modules/area-of-study/connected.js
+++ b/modules/gob-web/modules/area-of-study/connected.js
@@ -13,31 +13,17 @@ import {
 
 type Props = {
 	areaOfStudy: AreaQuery,
-	showCloseButton: boolean,
-	showEditButton: boolean,
 	student: Student,
 	changeStudent: ChangeStudentFunc,
 }
 
 type State = {|
 	isOpen: boolean,
-	confirmRemoval: boolean,
 |}
 
 class AreaOfStudyConnector extends React.Component<Props, State> {
 	state = {
 		isOpen: false,
-		confirmRemoval: false,
-	}
-
-	startRemovalConfirmation = (ev: Event) => {
-		ev.stopPropagation()
-		this.setState({confirmRemoval: true})
-	}
-
-	endRemovalConfirmation = (ev: Event) => {
-		ev.stopPropagation()
-		this.setState({confirmRemoval: false})
 	}
 
 	toggleAreaExpansion = (ev: Event) => {
@@ -72,14 +58,8 @@ class AreaOfStudyConnector extends React.Component<Props, State> {
 		}
 	}
 
-	removeArea = (ev: Event) => {
-		ev.stopPropagation()
-		let s = this.props.student.removeArea(this.props.areaOfStudy)
-		this.props.changeStudent(s)
-	}
-
 	render() {
-		let {areaOfStudy, student, showCloseButton, showEditButton} = this.props
+		let {areaOfStudy, student} = this.props
 
 		return (
 			<AreaOfStudyProvider areaOfStudy={areaOfStudy} student={student}>
@@ -92,15 +72,9 @@ class AreaOfStudyConnector extends React.Component<Props, State> {
 							results={results}
 							isOpen={this.state.isOpen}
 							onToggleOpen={this.toggleAreaExpansion}
-							onRemove={this.removeArea}
 							onAddOverride={this.addOverride}
 							onRemoveOverride={this.removeOverride}
 							onToggleOverride={this.toggleOverride}
-							onRemovalStart={this.startRemovalConfirmation}
-							onRemovalCancel={this.endRemovalConfirmation}
-							showCloseButton={showCloseButton}
-							showEditButton={showEditButton}
-							showConfirmRemoval={this.state.confirmRemoval}
 						/>
 					)
 				}}

--- a/modules/gob-web/modules/student/area-of-study-group.js
+++ b/modules/gob-web/modules/student/area-of-study-group.js
@@ -82,8 +82,6 @@ class AreaOfStudyGroup extends React.PureComponent<Props> {
 					<AreaOfStudy
 						areaOfStudy={area}
 						key={`${area.name}${String(area.revision)}`}
-						showCloseButton={showAreaPicker}
-						showEditButton={showAreaPicker}
 						student={this.props.student}
 					/>
 				))}


### PR DESCRIPTION
With the new area picker interface, which has giant [X] buttons attached to each entry, I don't think that we need the (x) buttons on the individual areas any longer.

Plus, they're buggy wrt. layout currently, ever since we added extra padding to FlatButton&co.

Closes #2306

![screen shot 2018-10-10 at 5 38 20 pm](https://user-images.githubusercontent.com/464441/46770010-590c7100-ccb3-11e8-916f-5a83243a77f9.png)
