### PR TITLE
More space at the bottom of the bottomtoolbar

### DIFF
--- a/modules/gob-web/modules/course/modal.js
+++ b/modules/gob-web/modules/course/modal.js
@@ -33,7 +33,7 @@ const ContainerModal = styled(Modal)`
 `
 
 const BottomToolbar = styled.div`
-	padding: 0 20px;
+	padding: 10px 20px;
 	border-top: 1px solid rgba(160, 160, 160, 0.2);
 	margin-top: 0.5em;
 	padding-top: 0.5em;


### PR DESCRIPTION
**Old**
<img width="746" alt="old" src="https://user-images.githubusercontent.com/5240843/46779629-e82a8080-ccd5-11e8-9240-523381710d40.png">

**New**
<img width="742" alt="new" src="https://user-images.githubusercontent.com/5240843/46779630-e82a8080-ccd5-11e8-9eb3-945c02de667d.png">
