### PR TITLE
Show certain pages as cards

### DIFF
--- a/modules/gob-web/app.js
+++ b/modules/gob-web/app.js
@@ -5,9 +5,10 @@ import {Router} from '@reach/router'
 import DocumentTitle from 'react-document-title'
 import HTML5Backend from 'react-dnd-html5-backend'
 import {DragDropContext} from 'react-dnd'
-import {createGlobalStyle} from 'styled-components'
+import styled, {createGlobalStyle} from 'styled-components'
 import Loadable from 'react-loadable'
 import {LoadingComponent} from './components/loading-comp'
+import {Card} from './components/card'
 
 let GlobalStyle = createGlobalStyle`
     *, *::before, *::after {
@@ -39,7 +40,23 @@ let GlobalStyle = createGlobalStyle`
     }
 `
 
-let NotFound = () => <h1>404 Not Found</h1>
+const NotFoundCard = styled(Card)`
+	margin: 40px auto;
+
+	max-width: 40em;
+	width: 100%;
+
+	padding: 20px;
+
+	text-align: center;
+`
+
+let NotFound = () => (
+	<NotFoundCard>
+		<h1>404 Not Found</h1>
+		<p>It looks like nothing was found at this location.</p>
+	</NotFoundCard>
+)
 
 let AreaEditor = Loadable({
 	loader: () => import('./screens/area-editor'),

--- a/modules/gob-web/modules/student/student.js
+++ b/modules/gob-web/modules/student/student.js
@@ -7,6 +7,7 @@ import {type IndividualStudentState} from '../../redux/students/reducers'
 import {Student as StudentObject} from '@gob/object-student'
 import type {Undoable} from '../../types'
 import styled from 'styled-components'
+import {Card} from '../../components/card'
 
 const Container = styled.div`
 	display: grid;
@@ -19,6 +20,17 @@ const Container = styled.div`
 	@media all and (min-width: 900px) {
 		grid-template-columns: 280px minmax(0, 1fr) 280px;
 	}
+`
+
+const CouldNotLoadCard = styled(Card)`
+	margin: 40px auto;
+
+	max-width: 40em;
+	width: 100%;
+
+	padding: 20px;
+
+	text-align: center;
 `
 
 type Props = {
@@ -39,7 +51,12 @@ export class Student extends React.Component<Props, State> {
 
 	render() {
 		if (!this.props.student) {
-			return <p>Student {this.props.studentId} could not be loaded.</p>
+			return (
+				<CouldNotLoadCard>
+					<h1>Could not load student</h1>
+					<p>Student {this.props.studentId} could not be loaded.</p>
+				</CouldNotLoadCard>
+			)
 		}
 
 		let {student} = this.props


### PR DESCRIPTION
* Page for when student could not be loaded (student)
* Page for when the resource could not be loaded (404)

Before | After
--|--
<img width="887" alt="1" src="https://user-images.githubusercontent.com/5240843/46908916-e4ba1380-cee6-11e8-9a42-c1fab70489b4.png"> | <img width="887" alt="2" src="https://user-images.githubusercontent.com/5240843/46908917-e552aa00-cee6-11e8-93a5-4819e8a9f44e.png">
<img width="887" alt="3" src="https://user-images.githubusercontent.com/5240843/46908918-e552aa00-cee6-11e8-993b-55c9cbbd9b7d.png"> | <img width="887" alt="4" src="https://user-images.githubusercontent.com/5240843/46908919-e552aa00-cee6-11e8-9608-9b392583ecf5.png">
