### PR TITLE
Always attach the window._db global instead of waiting for helpers/db to be loaded

### DIFF
--- a/modules/gob-web/helpers/db.js
+++ b/modules/gob-web/helpers/db.js
@@ -3,5 +3,3 @@
 import {createDatabase} from '@gob/web-database'
 
 export const db = createDatabase()
-
-global._db = db

--- a/modules/gob-web/index.js
+++ b/modules/gob-web/index.js
@@ -19,6 +19,10 @@ startAnalytics()
 import loadData from './workers/load-data'
 loadData().catch(err => console.error(err))
 
+// ... attach the db for debugging
+import {db} from './helpers/db'
+global._db = db
+
 // Kick off the GUI
 console.log('3. 2.. 1... Blast off! 🚀')
 


### PR DESCRIPTION
because I was trying to use it earlier, and it's not loaded on the main screen anymore.