### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hawkrives/gobbldygook/security/code-scanning/19](https://github.com/hawkrives/gobbldygook/security/code-scanning/19)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add `permissions: contents: read` at the top level of the workflow, just after the `name` field and before the `on` field. This will apply the least privilege (read-only access to repository contents) to all jobs in the workflow, unless a job specifically overrides it. No changes to job logic or steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
