### PR TITLE
allow uploading SARIF results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 permissions:
   contents: read
+  security-events: write # for uploading SARIF results
 
 on:
   push:


### PR DESCRIPTION
Fixes eslint runs (e.g. https://github.com/hawkrives/gobbldygook/actions/runs/16897406409/job/47869704546)

```
Run github/codeql-action/upload-sarif@76621b61decf072c1cee8dd1ce2d2a82d33c17ed
Warning: Resource not accessible by integration - https://docs.github.com/rest
Uploading code scanning results
  Processing sarif files: ["eslint-results.sarif"]
  Validating eslint-results.sarif
  Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
  Uploading results
  Warning: Resource not accessible by integration - https://docs.github.com/rest
  Error: Resource not accessible by integration - https://docs.github.com/rest
  Warning: Resource not accessible by integration - https://docs.github.com/rest
```